### PR TITLE
fix: add missing _pairKey method in EventDeduplicationService

### DIFF
--- a/lib/core/services/event_deduplication_service.dart
+++ b/lib/core/services/event_deduplication_service.dart
@@ -539,6 +539,13 @@ class EventDeduplicationService {
     return occurrences.any((occ) => AppDateUtils.isSameDay(occ.date, date));
   }
 
+  /// Creates a canonical key for an event pair to prevent duplicate
+  /// symmetric matches (A↔B and B↔A).
+  String _pairKey(String idA, String idB) {
+    // Lexicographic ordering ensures (A,B) and (B,A) produce the same key
+    return idA.compareTo(idB) <= 0 ? '$idA|$idB' : '$idB|$idA';
+  }
+
   // ─── Similarity functions ────────────────────────────────────
 
   /// Title similarity using normalized Levenshtein distance.


### PR DESCRIPTION
## Bug

\EventDeduplicationService.scan()\ calls \_pairKey(a.id, b.id)\ at line 323 to deduplicate symmetric event pairs, but this method was never defined in the class. This causes a \NoSuchMethodError\ at runtime whenever duplicate detection runs.

## Fix

Added the \_pairKey\ method that creates a canonical string key for any event pair using lexicographic ordering, ensuring \(A,B)\ and \(B,A)\ map to the same key.