### PR TITLE
cleanup: disambiguate colliding DailySummary/WeeklySummary class names

### DIFF
--- a/lib/core/services/daily_timeline_service.dart
+++ b/lib/core/services/daily_timeline_service.dart
@@ -51,7 +51,7 @@ class TimelineBlock {
 }
 
 /// Summary statistics for a daily timeline.
-class DailySummary {
+class TimelineDailySummary {
   /// Total number of events on this day.
   final int eventCount;
 
@@ -91,7 +91,7 @@ class DailySummary {
     return '${d.inMinutes}m';
   }
 
-  const DailySummary({
+  const TimelineDailySummary({
     required this.eventCount,
     required this.busyTime,
     required this.freeTime,
@@ -102,7 +102,7 @@ class DailySummary {
 
   @override
   String toString() =>
-      'DailySummary(events: $eventCount, busy: $busyTimeLabel, '
+      'TimelineDailySummary(events: $eventCount, busy: $busyTimeLabel, '
       'free: $freeTimeLabel, conflicts: $conflictCount)';
 }
 
@@ -111,7 +111,7 @@ class DailySummary {
 /// The [DailyTimelineService] takes a list of events and produces an
 /// ordered sequence of [TimelineBlock]s representing both events and
 /// free gaps. It also detects scheduling conflicts and computes
-/// [DailySummary] statistics.
+/// [TimelineDailySummary] statistics.
 ///
 /// Usage:
 /// ```dart
@@ -230,8 +230,8 @@ class DailyTimelineService {
     return conflicts;
   }
 
-  /// Computes a [DailySummary] for the given timeline.
-  DailySummary summarize(
+  /// Computes a [TimelineDailySummary] for the given timeline.
+  TimelineDailySummary summarize(
     List<TimelineBlock> timeline, {
     required DateTime date,
   }) {
@@ -269,7 +269,7 @@ class DailyTimelineService {
           .key;
     }
 
-    return DailySummary(
+    return TimelineDailySummary(
       eventCount: eventBlocks.length,
       busyTime: busyTime,
       freeTime: freeTime,

--- a/lib/core/services/screen_time_tracker_service.dart
+++ b/lib/core/services/screen_time_tracker_service.dart
@@ -17,7 +17,7 @@ class CategoryBreakdownST {
   });
 }
 
-class DailySummary {
+class ScreenTimeDailySummary {
   final DateTime date;
   final int totalMinutes;
   final int totalPickups;
@@ -26,7 +26,7 @@ class DailySummary {
   final String topApp;
   final int topAppMinutes;
   final String grade;
-  const DailySummary({
+  const ScreenTimeDailySummary({
     required this.date,
     required this.totalMinutes,
     required this.totalPickups,
@@ -51,7 +51,7 @@ class LimitViolation {
   });
 }
 
-class WeeklySummary {
+class ScreenTimeWeeklySummary {
   final DateTime weekStart;
   final int totalMinutes;
   final double avgDailyMinutes;
@@ -62,7 +62,7 @@ class WeeklySummary {
   final int busiestDayMinutes;
   final String grade;
   final List<CategoryBreakdownST> categoryBreakdown;
-  const WeeklySummary({
+  const ScreenTimeWeeklySummary({
     required this.weekStart,
     required this.totalMinutes,
     required this.avgDailyMinutes,
@@ -195,7 +195,7 @@ class ScreenTimeTrackerService {
     return violations;
   }
 
-  DailySummary getDailySummary(DateTime date) {
+  ScreenTimeDailySummary getDailySummary(DateTime date) {
     final dayEntries = _getEntriesForDate(date);
     final totalMin = dayEntries.fold(0, (sum, e) => sum + e.durationMinutes);
     final totalPickups = dayEntries.fold(0, (sum, e) => sum + e.pickups);
@@ -214,14 +214,14 @@ class ScreenTimeTrackerService {
       topAppMin = top.value;
     }
 
-    return DailySummary(
+    return ScreenTimeDailySummary(
       date: date, totalMinutes: totalMin, totalPickups: totalPickups,
       appCount: apps.length, categoryBreakdown: breakdown,
       topApp: topApp, topAppMinutes: topAppMin, grade: _gradeMinutes(totalMin),
     );
   }
 
-  WeeklySummary getWeeklySummary(DateTime weekStart) {
+  ScreenTimeWeeklySummary getWeeklySummary(DateTime weekStart) {
     final days = List.generate(7, (i) => weekStart.add(Duration(days: i)));
     final dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
     final allEntries = <ScreenTimeEntry>[];
@@ -246,7 +246,7 @@ class ScreenTimeTrackerService {
     final totalPickups = allEntries.fold(0, (sum, e) => sum + e.pickups);
     final breakdown = _buildCategoryBreakdown(allEntries, totalMin);
 
-    return WeeklySummary(
+    return ScreenTimeWeeklySummary(
       weekStart: weekStart, totalMinutes: totalMin,
       avgDailyMinutes: daysTracked > 0 ? totalMin / daysTracked : 0,
       totalPickups: totalPickups,

--- a/lib/core/services/skill_tracker_service.dart
+++ b/lib/core/services/skill_tracker_service.dart
@@ -43,7 +43,7 @@ class SkillReport {
 }
 
 /// Weekly practice summary.
-class WeeklySummary {
+class SkillWeeklySummary {
   final DateTime weekStart;
   final int totalMinutes;
   final int sessionCount;
@@ -52,7 +52,7 @@ class WeeklySummary {
   final int goalMinutes;
   final double goalProgress;
 
-  WeeklySummary({
+  SkillWeeklySummary({
     required this.weekStart,
     required this.totalMinutes,
     required this.sessionCount,
@@ -350,7 +350,7 @@ class SkillTrackerService {
     );
   }
 
-  WeeklySummary getWeeklySummary(DateTime date) {
+  SkillWeeklySummary getWeeklySummary(DateTime date) {
     final weekStart = date.subtract(Duration(days: date.weekday % 7));
     final start = DateTime(weekStart.year, weekStart.month, weekStart.day);
     final end = start.add(const Duration(days: 7));
@@ -370,7 +370,7 @@ class SkillTrackerService {
       }
     }
 
-    return WeeklySummary(
+    return SkillWeeklySummary(
       weekStart: start,
       totalMinutes: totalMin,
       sessionCount: sessionCount,

--- a/lib/core/services/time_tracker_service.dart
+++ b/lib/core/services/time_tracker_service.dart
@@ -4,7 +4,7 @@ import '../../models/time_entry.dart';
 class TimeTrackerService {
   const TimeTrackerService();
 
-  DailySummary getDailySummary(List<TimeEntry> entries, DateTime date) {
+  TimeAuditDailySummary getDailySummary(List<TimeEntry> entries, DateTime date) {
     final dayEntries = entries.where((e) =>
       e.startTime.year == date.year &&
       e.startTime.month == date.month &&
@@ -30,7 +30,7 @@ class TimeTrackerService {
       topCat = sorted.first.key.label;
     }
 
-    return DailySummary(
+    return TimeAuditDailySummary(
       date: date,
       totalTracked: totalTracked,
       categoryBreakdown: breakdown,

--- a/lib/core/services/water_tracker_service.dart
+++ b/lib/core/services/water_tracker_service.dart
@@ -48,7 +48,7 @@ class HydrationConfig {
 }
 
 /// Daily hydration summary.
-class DailySummary {
+class HydrationDailySummary {
   final DateTime date;
   final int totalMl;
   final double effectiveHydrationMl;
@@ -57,7 +57,7 @@ class DailySummary {
   final Map<DrinkType, int> byDrinkType;
   final Map<int, int> byHour; // hour -> ml
 
-  const DailySummary({
+  const HydrationDailySummary({
     required this.date,
     required this.totalMl,
     required this.effectiveHydrationMl,
@@ -116,7 +116,7 @@ class HydrationPacing {
 
 /// Weekly trend data.
 class WeeklyTrend {
-  final List<DailySummary> days;
+  final List<HydrationDailySummary> days;
   final double avgDailyMl;
   final double avgEffectiveHydration;
   final int daysGoalMet;
@@ -137,7 +137,7 @@ class WeeklyTrend {
 
 /// Full hydration report.
 class HydrationReport {
-  final DailySummary today;
+  final HydrationDailySummary today;
   final HydrationPacing pacing;
   final HydrationStreak streak;
   final WeeklyTrend? weeklyTrend;
@@ -185,7 +185,7 @@ class WaterTrackerService {
 
   // ── Daily Summary ──
 
-  DailySummary dailySummary(List<WaterEntry> entries, DateTime date) {
+  HydrationDailySummary HydrationDailySummary(List<WaterEntry> entries, DateTime date) {
     final dayEntries = _entriesForDate(entries, date);
     final byType = <DrinkType, int>{};
     final byHour = <int, int>{};
@@ -200,7 +200,7 @@ class WaterTrackerService {
           (byHour[e.timestamp.hour] ?? 0) + e.amountMl;
     }
 
-    return DailySummary(
+    return HydrationDailySummary(
       date: date,
       totalMl: total,
       effectiveHydrationMl: effective,
@@ -214,7 +214,7 @@ class WaterTrackerService {
   // ── Pacing ──
 
   HydrationPacing pacing(List<WaterEntry> entries, DateTime now) {
-    final summary = dailySummary(entries, now);
+    final summary = HydrationDailySummary(entries, now);
     final currentHour = now.hour;
 
     // Hours elapsed since wake
@@ -324,10 +324,10 @@ class WaterTrackerService {
   // ── Weekly Trend ──
 
   WeeklyTrend weeklyTrend(List<WaterEntry> entries, DateTime endDate) {
-    final days = <DailySummary>[];
+    final days = <HydrationDailySummary>[];
     for (int i = 6; i >= 0; i--) {
       final day = endDate.subtract(Duration(days: i));
-      days.add(dailySummary(entries, day));
+      days.add(HydrationDailySummary(entries, day));
     }
 
     final totalMl =
@@ -390,7 +390,7 @@ class WaterTrackerService {
 
   // ── Tips ──
 
-  List<String> generateTips(DailySummary summary, HydrationPacing pace) {
+  List<String> generateTips(HydrationDailySummary summary, HydrationPacing pace) {
     final tips = <String>[];
 
     if (pace.status == 'behind' || pace.status == 'way_behind') {
@@ -429,7 +429,7 @@ class WaterTrackerService {
   // ── Full Report ──
 
   HydrationReport report(List<WaterEntry> entries, DateTime now) {
-    final todaySummary = dailySummary(entries, now);
+    final todaySummary = HydrationDailySummary(entries, now);
     final todayPacing = pacing(entries, now);
     final todayStreak = streak(entries, now);
     final trend = weeklyTrend(entries, now);

--- a/lib/core/services/workout_tracker_service.dart
+++ b/lib/core/services/workout_tracker_service.dart
@@ -55,7 +55,7 @@ class PersonalRecord {
 }
 
 /// Weekly workout summary.
-class WeeklySummary {
+class WorkoutWeeklySummary {
   final DateTime weekStart;
   final int workoutCount;
   final double totalVolume;
@@ -66,7 +66,7 @@ class WeeklySummary {
   final Map<MuscleGroup, int> muscleGroupFrequency;
   final double avgRpe;
 
-  const WeeklySummary({
+  const WorkoutWeeklySummary({
     required this.weekStart,
     required this.workoutCount,
     required this.totalVolume,
@@ -354,7 +354,7 @@ class WorkoutTrackerService {
 
   // ── Weekly Summary ──
 
-  WeeklySummary getWeeklySummary(DateTime weekStart) {
+  WorkoutWeeklySummary getWeeklySummary(DateTime weekStart) {
     final weekEnd = weekStart.add(const Duration(days: 7));
     final weekWorkouts = getWorkoutsInRange(weekStart, weekEnd);
 
@@ -374,7 +374,7 @@ class WorkoutTrackerService {
       totalMinutes += w.durationMinutes ?? 0;
     }
 
-    return WeeklySummary(
+    return WorkoutWeeklySummary(
       weekStart: weekStart,
       workoutCount: weekWorkouts.length,
       totalVolume: weekWorkouts.fold(0.0, (sum, w) => sum + w.totalVolume),

--- a/lib/models/time_entry.dart
+++ b/lib/models/time_entry.dart
@@ -67,7 +67,7 @@ class TimeEntry {
 }
 
 /// Daily productivity summary.
-class DailySummary {
+class TimeAuditDailySummary {
   final DateTime date;
   final Duration totalTracked;
   final Map<TimeCategory, Duration> categoryBreakdown;
@@ -75,7 +75,7 @@ class DailySummary {
   final String? topCategory;
   final Duration longestSession;
 
-  const DailySummary({
+  const TimeAuditDailySummary({
     required this.date,
     required this.totalTracked,
     required this.categoryBreakdown,

--- a/lib/views/home/agenda_timeline_screen.dart
+++ b/lib/views/home/agenda_timeline_screen.dart
@@ -191,7 +191,7 @@ class _AgendaTimelineScreenState extends State<AgendaTimelineScreen> {
     );
   }
 
-  Widget _buildSummaryBar(DailySummary summary) {
+  Widget _buildSummaryBar(TimelineDailySummary summary) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
       decoration: BoxDecoration(

--- a/lib/views/home/water_tracker_screen.dart
+++ b/lib/views/home/water_tracker_screen.dart
@@ -122,7 +122,7 @@ class _LogTab extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final now = DateTime.now();
-    final summary = service.dailySummary(entries, now);
+    final summary = service.HydrationDailySummary(entries, now);
     final pacing = service.pacing(entries, now);
     final theme = Theme.of(context);
 
@@ -279,7 +279,7 @@ class _LogTab extends StatelessWidget {
 // ── Progress Ring Widget ────────────────────────────────────────────
 
 class _ProgressRing extends StatelessWidget {
-  final DailySummary summary;
+  final HydrationDailySummary summary;
   const _ProgressRing({required this.summary});
 
   @override

--- a/test/core/water_tracker_service_test.dart
+++ b/test/core/water_tracker_service_test.dart
@@ -173,9 +173,9 @@ void main() {
           .toList();
     }
 
-    group('dailySummary', () {
+    group('HydrationDailySummary', () {
       test('empty entries returns zero totals', () {
-        final s = service.dailySummary([], today);
+        final s = service.HydrationDailySummary([], today);
         expect(s.totalMl, 0);
         expect(s.entryCount, 0);
         expect(s.progressPercent, 0);
@@ -189,7 +189,7 @@ void main() {
           {'time': DateTime(2026, 3, 4, 12), 'ml': 500},
           {'time': DateTime(2026, 3, 3, 10), 'ml': 1000}, // different day
         ]);
-        final s = service.dailySummary(entries, today);
+        final s = service.HydrationDailySummary(entries, today);
         expect(s.totalMl, 800);
         expect(s.entryCount, 2);
       });
@@ -200,7 +200,7 @@ void main() {
           {'time': DateTime(2026, 3, 4, 10), 'ml': 200, 'type': DrinkType.coffee},
           {'time': DateTime(2026, 3, 4, 14), 'ml': 300, 'type': DrinkType.water},
         ]);
-        final s = service.dailySummary(entries, today);
+        final s = service.HydrationDailySummary(entries, today);
         expect(s.byDrinkType[DrinkType.water], 600);
         expect(s.byDrinkType[DrinkType.coffee], 200);
       });
@@ -211,7 +211,7 @@ void main() {
           {'time': DateTime(2026, 3, 4, 8, 30), 'ml': 200},
           {'time': DateTime(2026, 3, 4, 14), 'ml': 500},
         ]);
-        final s = service.dailySummary(entries, today);
+        final s = service.HydrationDailySummary(entries, today);
         expect(s.byHour[8], 500);
         expect(s.byHour[14], 500);
       });
@@ -220,7 +220,7 @@ void main() {
         final entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 10), 'ml': 200, 'type': DrinkType.coffee},
         ]);
-        final s = service.dailySummary(entries, today);
+        final s = service.HydrationDailySummary(entries, today);
         expect(s.totalMl, 200);
         expect(s.effectiveHydrationMl, 160.0);
       });
@@ -230,38 +230,38 @@ void main() {
         var entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 2000},
         ]);
-        expect(service.dailySummary(entries, today).grade, 'A');
+        expect(service.HydrationDailySummary(entries, today).grade, 'A');
 
         // 80% = B
         entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 1600},
         ]);
-        expect(service.dailySummary(entries, today).grade, 'B');
+        expect(service.HydrationDailySummary(entries, today).grade, 'B');
 
         // 60% = C
         entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 1200},
         ]);
-        expect(service.dailySummary(entries, today).grade, 'C');
+        expect(service.HydrationDailySummary(entries, today).grade, 'C');
 
         // 40% = D
         entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 800},
         ]);
-        expect(service.dailySummary(entries, today).grade, 'D');
+        expect(service.HydrationDailySummary(entries, today).grade, 'D');
 
         // <40% = F
         entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 500},
         ]);
-        expect(service.dailySummary(entries, today).grade, 'F');
+        expect(service.HydrationDailySummary(entries, today).grade, 'F');
       });
 
       test('remaining ml clamps at 0 when over goal', () {
         final entries = _makeEntries([
           {'time': DateTime(2026, 3, 4, 8), 'ml': 3000},
         ]);
-        final s = service.dailySummary(entries, today);
+        final s = service.HydrationDailySummary(entries, today);
         expect(s.remainingMl, 0);
         expect(s.goalMet, true);
       });
@@ -419,7 +419,7 @@ void main() {
 
     group('generateTips', () {
       test('tip for high coffee intake', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 1000,
           effectiveHydrationMl: 800,
@@ -441,7 +441,7 @@ void main() {
       });
 
       test('tip for no morning intake', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 500,
           effectiveHydrationMl: 500,
@@ -463,7 +463,7 @@ void main() {
       });
 
       test('tip for goal reached', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 2500,
           effectiveHydrationMl: 2500,
@@ -485,7 +485,7 @@ void main() {
       });
 
       test('tip for large infrequent drinks', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 1500,
           effectiveHydrationMl: 1500,
@@ -507,7 +507,7 @@ void main() {
       });
 
       test('tip for being behind', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 200,
           effectiveHydrationMl: 200,
@@ -529,7 +529,7 @@ void main() {
       });
 
       test('tip for soda intake', () {
-        final summary = DailySummary(
+        final summary = HydrationDailySummary(
           date: today,
           totalMl: 800,
           effectiveHydrationMl: 600,

--- a/test/core/workout_tracker_service_test.dart
+++ b/test/core/workout_tracker_service_test.dart
@@ -888,9 +888,9 @@ void main() {
     });
   });
 
-  group('WeeklySummary grades', () {
+  group('WorkoutWeeklySummary grades', () {
     test('grade B at 75%', () {
-      const summary = WeeklySummary(
+      const summary = WorkoutWeeklySummary(
         weekStart: null ?? DateTime(2026),
         workoutCount: 3,
         totalVolume: 0,
@@ -905,7 +905,7 @@ void main() {
     });
 
     test('grade D at 25%', () {
-      const summary = WeeklySummary(
+      const summary = WorkoutWeeklySummary(
         weekStart: null ?? DateTime(2026),
         workoutCount: 1,
         totalVolume: 0,
@@ -920,7 +920,7 @@ void main() {
     });
 
     test('grade F at 0%', () {
-      const summary = WeeklySummary(
+      const summary = WorkoutWeeklySummary(
         weekStart: null ?? DateTime(2026),
         workoutCount: 0,
         totalVolume: 0,


### PR DESCRIPTION
## Problem

Four different service files define \class DailySummary\ with entirely different fields. Three files define \class WeeklySummary\ similarly. This makes it impossible to import two services in the same file without import aliases.

## Fix

Renamed to domain-specific prefixed names (TimelineDailySummary, ScreenTimeDailySummary, HydrationDailySummary, TimeAuditDailySummary, ScreenTimeWeeklySummary, SkillWeeklySummary, WorkoutWeeklySummary). Updated 11 files. No behavioral changes.