### PR TITLE
fix: add retry logic and failure callbacks to EventService persistence

### DIFF
--- a/lib/core/services/event_service.dart
+++ b/lib/core/services/event_service.dart
@@ -3,6 +3,11 @@ import '../../data/repositories/event_repository.dart';
 import '../../models/event_model.dart';
 import '../../state/providers/event_provider.dart';
 
+/// Callback for persistence failures that the UI layer can handle
+/// (e.g. showing a snackbar or marking an event as unsaved).
+typedef PersistenceFailureCallback = void Function(
+    String action, String? eventId, Object error);
+
 /// Coordinates event persistence and in-memory state management.
 ///
 /// This service eliminates the duplicated "update provider + persist to
@@ -15,21 +20,35 @@ import '../../state/providers/event_provider.dart';
 /// ```dart
 /// final service = EventService(
 ///   provider: context.read<EventProvider>(),
+///   onPersistenceFailure: (action, id, error) {
+///     ScaffoldMessenger.of(context).showSnackBar(
+///       SnackBar(content: Text('Failed to $action event')),
+///     );
+///   },
 /// );
 /// await service.addEvent(newEvent);
 /// await service.deleteEvent(event.id);
 /// ```
 ///
-/// Persistence errors are caught and logged — they don't crash the UI.
+/// Persistence errors are retried up to [maxRetries] times with
+/// exponential backoff. If all retries fail, the [onPersistenceFailure]
+/// callback is invoked (if provided) so the UI can notify the user.
 /// The in-memory state is always updated first so the UI stays responsive
 /// even if the disk write fails.
 class EventService {
   final EventProvider _provider;
   final EventRepository _repository;
+  final PersistenceFailureCallback? onPersistenceFailure;
+  final int maxRetries;
+
+  /// Base delay for exponential backoff (doubles on each retry).
+  static const Duration _baseDelay = Duration(milliseconds: 200);
 
   EventService({
     required EventProvider provider,
     EventRepository? repository,
+    this.onPersistenceFailure,
+    this.maxRetries = 3,
   })  : _provider = provider,
         _repository = repository ?? EventRepository();
 
@@ -52,30 +71,49 @@ class EventService {
   /// Adds an event to both the in-memory provider and SQLite.
   Future<void> addEvent(EventModel event) async {
     _provider.addEvent(event);
-    await _persist(() => _repository.saveEvent(event.toJson()), 'add');
+    await _persist(
+        () => _repository.saveEvent(event.toJson()), 'add', event.id);
   }
 
   /// Updates an existing event in both the provider and SQLite.
   Future<void> updateEvent(EventModel event) async {
     _provider.updateEvent(event);
-    await _persist(() => _repository.updateEvent(event.toJson()), 'update');
+    await _persist(
+        () => _repository.updateEvent(event.toJson()), 'update', event.id);
   }
 
   /// Removes an event by [id] from both the provider and SQLite.
   Future<void> deleteEvent(String id) async {
     _provider.removeEvent(id);
-    await _persist(() => _repository.deleteEvent(id), 'delete');
+    await _persist(() => _repository.deleteEvent(id), 'delete', id);
   }
 
-  /// Wraps a persistence operation with error handling.
+  /// Wraps a persistence operation with retry logic and error handling.
   ///
+  /// Retries up to [maxRetries] times with exponential backoff
+  /// (200ms, 400ms, 800ms) for transient disk I/O failures.
   /// The in-memory state is already updated before this is called,
   /// so the UI stays responsive regardless of disk I/O outcome.
-  Future<void> _persist(Future<void> Function() operation, String action) async {
-    try {
-      await operation();
-    } catch (e) {
-      debugPrint('EventService: Failed to $action event in storage: $e');
+  /// On final failure, invokes [onPersistenceFailure] if set.
+  Future<void> _persist(
+      Future<void> Function() operation, String action, String? eventId) async {
+    Object? lastError;
+    for (int attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        await operation();
+        return; // Success
+      } catch (e) {
+        lastError = e;
+        debugPrint(
+            'EventService: Failed to $action event (attempt ${attempt + 1}/${maxRetries + 1}): $e');
+        if (attempt < maxRetries) {
+          await Future<void>.delayed(_baseDelay * (1 << attempt));
+        }
+      }
+    }
+    // All retries exhausted — notify the UI layer
+    if (onPersistenceFailure != null && lastError != null) {
+      onPersistenceFailure!(action, eventId, lastError!);
     }
   }
 }


### PR DESCRIPTION
Fixes #44

`EventService._persist()` previously caught all errors silently — events that failed to save to SQLite appeared in the UI but vanished on restart with zero indication to the user.

## Changes

### Retry with exponential backoff
Transient disk I/O failures now get 3 retry attempts (200ms → 400ms → 800ms). Each failed attempt is logged with the attempt number.

### Failure callback for the UI layer
New `PersistenceFailureCallback` typedef and `onPersistenceFailure` parameter:

```dart
final service = EventService(
  provider: context.read<EventProvider>(),
  onPersistenceFailure: (action, eventId, error) {
    ScaffoldMessenger.of(context).showSnackBar(
      SnackBar(content: Text('Failed to $action event — changes may not be saved')),
    );
  },
);
```

The callback receives the action name (`add`/`update`/`delete`), the event ID, and the error object — enough for the UI to show targeted feedback or queue a manual retry.

### Configurable retries
`maxRetries` defaults to 3 but can be set to 0 for fast unit tests.

## Before vs After

| Scenario | Before | After |
|----------|--------|-------|
| Transient disk error | Silent data loss | Retry 3x with backoff |
| Persistent disk error | Silent data loss | Retry 3x, then notify UI |
| Debugging | Single `debugPrint` line | Per-attempt logging with attempt count |
| UI notification | None | `onPersistenceFailure` callback |
