### PR TITLE
feat: Travel Log Screen — 4-tab trip tracker with stats & insights (35 tests)

### DIFF
--- a/lib/core/services/travel_log_service.dart
+++ b/lib/core/services/travel_log_service.dart
@@ -1,0 +1,221 @@
+import '../../models/travel_entry.dart';
+
+/// Service for computing travel log statistics and insights.
+class TravelLogService {
+  const TravelLogService();
+
+  /// Compute aggregate travel statistics.
+  TravelStats computeStats(List<TravelEntry> entries) {
+    if (entries.isEmpty) {
+      return const TravelStats(
+        totalTrips: 0,
+        totalDays: 0,
+        countriesVisited: 0,
+        citiesVisited: 0,
+        totalSpent: 0,
+        avgTripDuration: 0,
+        avgRating: 0,
+        typeBreakdown: {},
+        transportBreakdown: {},
+        longestTripDays: 0,
+      );
+    }
+
+    final completed = entries.where((e) => e.isCompleted).toList();
+    int totalDays = 0;
+    double totalCost = 0;
+    double ratingSum = 0;
+    int ratedCount = 0;
+    int longestTrip = 0;
+    final countries = <String>{};
+    final cities = <String>{};
+    final typeMap = <TripType, int>{};
+    final transportMap = <TripTransport, int>{};
+    final destCount = <String, int>{};
+
+    for (final e in completed) {
+      totalDays += e.durationDays;
+      totalCost += e.totalCost ?? 0;
+      if (e.rating != null) {
+        ratingSum += e.rating!.value;
+        ratedCount++;
+      }
+      if (e.durationDays > longestTrip) longestTrip = e.durationDays;
+      if (e.country != null && e.country!.isNotEmpty) {
+        countries.add(e.country!);
+      }
+      cities.add(e.destination);
+      typeMap[e.type] = (typeMap[e.type] ?? 0) + 1;
+      transportMap[e.transport] = (transportMap[e.transport] ?? 0) + 1;
+      destCount[e.destination] = (destCount[e.destination] ?? 0) + 1;
+    }
+
+    String? favDest;
+    int favCount = 0;
+    for (final entry in destCount.entries) {
+      if (entry.value > favCount) {
+        favCount = entry.value;
+        favDest = entry.key;
+      }
+    }
+
+    return TravelStats(
+      totalTrips: completed.length,
+      totalDays: totalDays,
+      countriesVisited: countries.length,
+      citiesVisited: cities.length,
+      totalSpent: totalCost,
+      avgTripDuration:
+          completed.isEmpty ? 0 : totalDays / completed.length,
+      avgRating: ratedCount == 0 ? 0 : ratingSum / ratedCount,
+      typeBreakdown: typeMap,
+      transportBreakdown: transportMap,
+      favoriteDestination: favDest,
+      longestTripDays: longestTrip,
+    );
+  }
+
+  /// Get monthly cost breakdown.
+  List<TravelMonthlyCost> getMonthlyCosts(List<TravelEntry> entries) {
+    final completed =
+        entries.where((e) => e.isCompleted && e.totalCost != null).toList();
+    final monthMap = <String, _MonthAccum>{};
+
+    for (final e in completed) {
+      final key = '${e.startDate.year}-${e.startDate.month}';
+      final accum = monthMap.putIfAbsent(
+        key,
+        () => _MonthAccum(e.startDate.year, e.startDate.month),
+      );
+      accum.total += e.totalCost!;
+      accum.count++;
+    }
+
+    final result = monthMap.values
+        .map((a) => TravelMonthlyCost(
+              year: a.year,
+              month: a.month,
+              total: a.total,
+              tripCount: a.count,
+            ))
+        .toList()
+      ..sort((a, b) {
+        final y = a.year.compareTo(b.year);
+        return y != 0 ? y : a.month.compareTo(b.month);
+      });
+    return result;
+  }
+
+  /// Get upcoming trips sorted by start date.
+  List<TravelEntry> getUpcoming(List<TravelEntry> entries) {
+    final now = DateTime.now();
+    return entries
+        .where((e) => e.startDate.isAfter(now) && !e.isCompleted)
+        .toList()
+      ..sort((a, b) => a.startDate.compareTo(b.startDate));
+  }
+
+  /// Get trips filtered by year.
+  List<TravelEntry> getByYear(List<TravelEntry> entries, int year) {
+    return entries
+        .where((e) => e.startDate.year == year)
+        .toList()
+      ..sort((a, b) => b.startDate.compareTo(a.startDate));
+  }
+
+  /// Get unique years from entries.
+  List<int> getYears(List<TravelEntry> entries) {
+    final years = entries.map((e) => e.startDate.year).toSet().toList()
+      ..sort((a, b) => b.compareTo(a));
+    return years;
+  }
+
+  /// Generate travel insights.
+  List<TravelInsight> generateInsights(List<TravelEntry> entries) {
+    final insights = <TravelInsight>[];
+    final stats = computeStats(entries);
+
+    if (stats.totalTrips == 0) return insights;
+
+    insights.add(TravelInsight(
+      title: 'Total Travel',
+      value: '${stats.totalDays} days across ${stats.totalTrips} trips',
+      emoji: '🌍',
+    ));
+
+    if (stats.countriesVisited > 0) {
+      insights.add(TravelInsight(
+        title: 'Countries',
+        value: '${stats.countriesVisited} countries explored',
+        emoji: '🗺️',
+      ));
+    }
+
+    if (stats.avgRating > 0) {
+      insights.add(TravelInsight(
+        title: 'Avg Rating',
+        value: '${stats.avgRating.toStringAsFixed(1)} / 5.0',
+        emoji: '⭐',
+      ));
+    }
+
+    if (stats.totalSpent > 0) {
+      final avg = stats.totalSpent / stats.totalTrips;
+      insights.add(TravelInsight(
+        title: 'Avg Trip Cost',
+        value: '\$${avg.toStringAsFixed(0)}',
+        emoji: '💰',
+      ));
+    }
+
+    if (stats.longestTripDays > 1) {
+      insights.add(TravelInsight(
+        title: 'Longest Trip',
+        value: '${stats.longestTripDays} days',
+        emoji: '📅',
+      ));
+    }
+
+    if (stats.favoriteDestination != null) {
+      insights.add(TravelInsight(
+        title: 'Most Visited',
+        value: stats.favoriteDestination!,
+        emoji: '📍',
+      ));
+    }
+
+    // Best-rated transport
+    if (stats.transportBreakdown.isNotEmpty) {
+      final topTransport = stats.transportBreakdown.entries
+          .reduce((a, b) => a.value >= b.value ? a : b);
+      insights.add(TravelInsight(
+        title: 'Preferred Transport',
+        value: topTransport.key.label,
+        emoji: topTransport.key.emoji,
+      ));
+    }
+
+    return insights;
+  }
+}
+
+class _MonthAccum {
+  final int year;
+  final int month;
+  double total = 0;
+  int count = 0;
+  _MonthAccum(this.year, this.month);
+}
+
+/// A single travel insight.
+class TravelInsight {
+  final String title;
+  final String value;
+  final String emoji;
+
+  const TravelInsight({
+    required this.title,
+    required this.value,
+    required this.emoji,
+  });
+}

--- a/lib/models/travel_entry.dart
+++ b/lib/models/travel_entry.dart
@@ -1,0 +1,184 @@
+/// Model classes for the Travel Log feature.
+
+/// Type of trip.
+enum TripType {
+  leisure('Leisure', '🏖️'),
+  business('Business', '💼'),
+  adventure('Adventure', '🏔️'),
+  roadTrip('Road Trip', '🚗'),
+  weekend('Weekend Getaway', '🌅'),
+  family('Family Visit', '👨‍👩‍👧‍👦'),
+  solo('Solo Travel', '🎒'),
+  cultural('Cultural', '🏛️');
+
+  final String label;
+  final String emoji;
+  const TripType(this.label, this.emoji);
+}
+
+/// Primary transport mode used for the trip.
+enum TripTransport {
+  flight('Flight', '✈️'),
+  car('Car', '🚗'),
+  train('Train', '🚆'),
+  bus('Bus', '🚌'),
+  cruise('Cruise', '🚢'),
+  bike('Bike', '🚲'),
+  mixed('Mixed', '🔀');
+
+  final String label;
+  final String emoji;
+  const TripTransport(this.label, this.emoji);
+}
+
+/// Trip rating.
+enum TripRating {
+  amazing(5, 'Amazing', '🤩'),
+  great(4, 'Great', '😄'),
+  good(3, 'Good', '🙂'),
+  okay(2, 'Okay', '😐'),
+  disappointing(1, 'Disappointing', '😕');
+
+  final int value;
+  final String label;
+  final String emoji;
+  const TripRating(this.value, this.label, this.emoji);
+}
+
+/// A single travel log entry.
+class TravelEntry {
+  final String id;
+  final String destination;
+  final String? country;
+  final DateTime startDate;
+  final DateTime endDate;
+  final TripType type;
+  final TripTransport transport;
+  final TripRating? rating;
+  final double? totalCost;
+  final String? currency;
+  final List<String> highlights;
+  final String? notes;
+  final bool isCompleted;
+
+  const TravelEntry({
+    required this.id,
+    required this.destination,
+    this.country,
+    required this.startDate,
+    required this.endDate,
+    required this.type,
+    required this.transport,
+    this.rating,
+    this.totalCost,
+    this.currency,
+    this.highlights = const [],
+    this.notes,
+    this.isCompleted = true,
+  });
+
+  /// Trip duration in days.
+  int get durationDays {
+    final diff = endDate.difference(startDate).inDays;
+    return diff < 1 ? 1 : diff + 1;
+  }
+
+  /// Cost per day (if cost provided).
+  double? get costPerDay =>
+      totalCost != null ? totalCost! / durationDays : null;
+
+  /// Whether trip is currently happening.
+  bool get isOngoing {
+    final now = DateTime.now();
+    return now.isAfter(startDate) && now.isBefore(endDate) && !isCompleted;
+  }
+
+  /// Whether trip is in the future.
+  bool get isUpcoming =>
+      startDate.isAfter(DateTime.now()) && !isCompleted;
+
+  TravelEntry copyWith({
+    String? destination,
+    String? country,
+    DateTime? startDate,
+    DateTime? endDate,
+    TripType? type,
+    TripTransport? transport,
+    TripRating? rating,
+    double? totalCost,
+    String? currency,
+    List<String>? highlights,
+    String? notes,
+    bool? isCompleted,
+  }) {
+    return TravelEntry(
+      id: id,
+      destination: destination ?? this.destination,
+      country: country ?? this.country,
+      startDate: startDate ?? this.startDate,
+      endDate: endDate ?? this.endDate,
+      type: type ?? this.type,
+      transport: transport ?? this.transport,
+      rating: rating ?? this.rating,
+      totalCost: totalCost ?? this.totalCost,
+      currency: currency ?? this.currency,
+      highlights: highlights ?? this.highlights,
+      notes: notes ?? this.notes,
+      isCompleted: isCompleted ?? this.isCompleted,
+    );
+  }
+}
+
+/// Travel statistics summary.
+class TravelStats {
+  final int totalTrips;
+  final int totalDays;
+  final int countriesVisited;
+  final int citiesVisited;
+  final double totalSpent;
+  final double avgTripDuration;
+  final double avgRating;
+  final Map<TripType, int> typeBreakdown;
+  final Map<TripTransport, int> transportBreakdown;
+  final String? favoriteDestination;
+  final int longestTripDays;
+
+  const TravelStats({
+    required this.totalTrips,
+    required this.totalDays,
+    required this.countriesVisited,
+    required this.citiesVisited,
+    required this.totalSpent,
+    required this.avgTripDuration,
+    required this.avgRating,
+    required this.typeBreakdown,
+    required this.transportBreakdown,
+    this.favoriteDestination,
+    required this.longestTripDays,
+  });
+}
+
+/// Monthly travel cost summary.
+class TravelMonthlyCost {
+  final int year;
+  final int month;
+  final double total;
+  final int tripCount;
+
+  const TravelMonthlyCost({
+    required this.year,
+    required this.month,
+    required this.total,
+    required this.tripCount,
+  });
+
+  String get label => '${_monthName(month)} $year';
+
+  static String _monthName(int m) {
+    const names = [
+      '', 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+      'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+    ];
+    return names[m.clamp(1, 12)];
+  }
+}

--- a/lib/views/home/home_screen.dart
+++ b/lib/views/home/home_screen.dart
@@ -42,6 +42,7 @@ import 'focus_time_screen.dart';
 import 'weekly_planner_screen.dart';
 import 'chore_tracker_screen.dart';
 import 'time_budget_screen.dart';
+import 'travel_log_screen.dart';
 import '../widgets/next_up_banner.dart';
 
 /// Sort criteria for the event list.
@@ -684,6 +685,16 @@ class _HomeScreenState extends State<HomeScreen> {
             },
             tooltip: 'Time budget',
           ),
+          // Travel log button
+          IconButton(
+            icon: const Icon(Icons.flight),
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const TravelLogScreen()),
+              );
+            },
+            tooltip: 'Travel log',
+          ),
           // Sort button
           IconButton(
             icon: const Icon(Icons.sort),
@@ -1049,3 +1060,4 @@ class _HomeScreenState extends State<HomeScreen> {
     );
   }
 }
+

--- a/lib/views/home/travel_log_screen.dart
+++ b/lib/views/home/travel_log_screen.dart
@@ -1,0 +1,693 @@
+import 'package:flutter/material.dart';
+import '../../models/travel_entry.dart';
+import '../../core/services/travel_log_service.dart';
+
+/// Travel Log screen — 4-tab UI for logging and reviewing trips.
+class TravelLogScreen extends StatefulWidget {
+  const TravelLogScreen({super.key});
+  @override
+  State<TravelLogScreen> createState() => _TravelLogScreenState();
+}
+
+class _TravelLogScreenState extends State<TravelLogScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  final _service = const TravelLogService();
+  final List<TravelEntry> _entries = [];
+  int? _filterYear;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 4, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _addEntry(TravelEntry entry) {
+    setState(() => _entries.add(entry));
+  }
+
+  void _deleteEntry(String id) {
+    setState(() => _entries.removeWhere((e) => e.id == id));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('✈️ Travel Log'),
+        bottom: TabBar(
+          controller: _tabController,
+          isScrollable: true,
+          tabs: const [
+            Tab(icon: Icon(Icons.add_location_alt), text: 'Log'),
+            Tab(icon: Icon(Icons.history), text: 'Trips'),
+            Tab(icon: Icon(Icons.bar_chart), text: 'Stats'),
+            Tab(icon: Icon(Icons.lightbulb_outline), text: 'Insights'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _LogTab(onAdd: _addEntry),
+          _TripsTab(
+            entries: _entries,
+            service: _service,
+            filterYear: _filterYear,
+            onYearChanged: (y) => setState(() => _filterYear = y),
+            onDelete: _deleteEntry,
+          ),
+          _StatsTab(entries: _entries, service: _service),
+          _InsightsTab(entries: _entries, service: _service),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── Log Tab ───────────────────────────────────────────────────────────
+
+class _LogTab extends StatefulWidget {
+  final void Function(TravelEntry) onAdd;
+  const _LogTab({required this.onAdd});
+  @override
+  State<_LogTab> createState() => _LogTabState();
+}
+
+class _LogTabState extends State<_LogTab> {
+  final _destController = TextEditingController();
+  final _countryController = TextEditingController();
+  final _costController = TextEditingController();
+  final _notesController = TextEditingController();
+  final _highlightController = TextEditingController();
+  DateTime _startDate = DateTime.now();
+  DateTime _endDate = DateTime.now().add(const Duration(days: 3));
+  TripType _type = TripType.leisure;
+  TripTransport _transport = TripTransport.flight;
+  TripRating? _rating;
+  final List<String> _highlights = [];
+  int _nextId = 1;
+
+  void _addHighlight() {
+    final text = _highlightController.text.trim();
+    if (text.isNotEmpty) {
+      setState(() {
+        _highlights.add(text);
+        _highlightController.clear();
+      });
+    }
+  }
+
+  void _submit() {
+    final dest = _destController.text.trim();
+    if (dest.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please enter a destination')),
+      );
+      return;
+    }
+    if (_endDate.isBefore(_startDate)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('End date must be after start date')),
+      );
+      return;
+    }
+
+    final entry = TravelEntry(
+      id: 'trip_${_nextId++}',
+      destination: dest,
+      country: _countryController.text.trim().isEmpty
+          ? null
+          : _countryController.text.trim(),
+      startDate: _startDate,
+      endDate: _endDate,
+      type: _type,
+      transport: _transport,
+      rating: _rating,
+      totalCost: double.tryParse(_costController.text),
+      highlights: List.from(_highlights),
+      notes: _notesController.text.trim().isEmpty
+          ? null
+          : _notesController.text.trim(),
+    );
+    widget.onAdd(entry);
+    _destController.clear();
+    _countryController.clear();
+    _costController.clear();
+    _notesController.clear();
+    _highlightController.clear();
+    setState(() {
+      _highlights.clear();
+      _rating = null;
+    });
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Trip to $dest logged! ✈️')),
+    );
+  }
+
+  Future<void> _pickDate(bool isStart) async {
+    final initial = isStart ? _startDate : _endDate;
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: initial,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() {
+        if (isStart) {
+          _startDate = picked;
+          if (_endDate.isBefore(_startDate)) {
+            _endDate = _startDate.add(const Duration(days: 1));
+          }
+        } else {
+          _endDate = picked;
+        }
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _destController.dispose();
+    _countryController.dispose();
+    _costController.dispose();
+    _notesController.dispose();
+    _highlightController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Destination
+        TextField(
+          controller: _destController,
+          decoration: const InputDecoration(
+            labelText: 'Destination *',
+            prefixIcon: Icon(Icons.location_on),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 12),
+        // Country
+        TextField(
+          controller: _countryController,
+          decoration: const InputDecoration(
+            labelText: 'Country',
+            prefixIcon: Icon(Icons.flag),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Date row
+        Row(
+          children: [
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: () => _pickDate(true),
+                icon: const Icon(Icons.calendar_today),
+                label: Text(
+                  '${_startDate.month}/${_startDate.day}/${_startDate.year}',
+                ),
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 8),
+              child: Text('→'),
+            ),
+            Expanded(
+              child: OutlinedButton.icon(
+                onPressed: () => _pickDate(false),
+                icon: const Icon(Icons.calendar_today),
+                label: Text(
+                  '${_endDate.month}/${_endDate.day}/${_endDate.year}',
+                ),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        // Trip type chips
+        const Text('Trip Type',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: TripType.values.map((t) {
+            return ChoiceChip(
+              label: Text('${t.emoji} ${t.label}'),
+              selected: _type == t,
+              onSelected: (_) => setState(() => _type = t),
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 16),
+        // Transport chips
+        const Text('Transport',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: TripTransport.values.map((t) {
+            return ChoiceChip(
+              label: Text('${t.emoji} ${t.label}'),
+              selected: _transport == t,
+              onSelected: (_) => setState(() => _transport = t),
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 16),
+        // Rating chips
+        const Text('Rating',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          runSpacing: 4,
+          children: TripRating.values.map((r) {
+            return ChoiceChip(
+              label: Text('${r.emoji} ${r.label}'),
+              selected: _rating == r,
+              onSelected: (_) => setState(() => _rating = r),
+            );
+          }).toList(),
+        ),
+        const SizedBox(height: 16),
+        // Cost
+        TextField(
+          controller: _costController,
+          keyboardType: TextInputType.number,
+          decoration: const InputDecoration(
+            labelText: 'Total Cost (\$)',
+            prefixIcon: Icon(Icons.attach_money),
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 16),
+        // Highlights
+        const Text('Highlights',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _highlightController,
+                decoration: const InputDecoration(
+                  hintText: 'Add a highlight...',
+                  border: OutlineInputBorder(),
+                  isDense: true,
+                ),
+                onSubmitted: (_) => _addHighlight(),
+              ),
+            ),
+            const SizedBox(width: 8),
+            IconButton(
+              onPressed: _addHighlight,
+              icon: const Icon(Icons.add_circle),
+            ),
+          ],
+        ),
+        if (_highlights.isNotEmpty) ...[
+          const SizedBox(height: 8),
+          Wrap(
+            spacing: 6,
+            runSpacing: 4,
+            children: _highlights.asMap().entries.map((e) {
+              return Chip(
+                label: Text(e.value),
+                onDeleted: () =>
+                    setState(() => _highlights.removeAt(e.key)),
+              );
+            }).toList(),
+          ),
+        ],
+        const SizedBox(height: 16),
+        // Notes
+        TextField(
+          controller: _notesController,
+          maxLines: 3,
+          decoration: const InputDecoration(
+            labelText: 'Notes',
+            prefixIcon: Icon(Icons.note),
+            border: OutlineInputBorder(),
+            alignLabelWithHint: true,
+          ),
+        ),
+        const SizedBox(height: 24),
+        // Submit
+        FilledButton.icon(
+          onPressed: _submit,
+          icon: const Icon(Icons.flight_takeoff),
+          label: const Text('Log Trip'),
+          style: FilledButton.styleFrom(
+            minimumSize: const Size(double.infinity, 48),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─── Trips Tab ─────────────────────────────────────────────────────────
+
+class _TripsTab extends StatelessWidget {
+  final List<TravelEntry> entries;
+  final TravelLogService service;
+  final int? filterYear;
+  final ValueChanged<int?> onYearChanged;
+  final ValueChanged<String> onDelete;
+
+  const _TripsTab({
+    required this.entries,
+    required this.service,
+    required this.filterYear,
+    required this.onYearChanged,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (entries.isEmpty) {
+      return const Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('✈️', style: TextStyle(fontSize: 48)),
+            SizedBox(height: 12),
+            Text('No trips logged yet',
+                style: TextStyle(fontSize: 18, color: Colors.grey)),
+            Text('Start by adding your first trip!',
+                style: TextStyle(color: Colors.grey)),
+          ],
+        ),
+      );
+    }
+
+    final years = service.getYears(entries);
+    final filtered = filterYear != null
+        ? service.getByYear(entries, filterYear!)
+        : List<TravelEntry>.from(entries)
+      ..sort((a, b) => b.startDate.compareTo(a.startDate));
+
+    return Column(
+      children: [
+        // Year filter
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(
+              children: [
+                ChoiceChip(
+                  label: const Text('All'),
+                  selected: filterYear == null,
+                  onSelected: (_) => onYearChanged(null),
+                ),
+                const SizedBox(width: 8),
+                ...years.map((y) => Padding(
+                      padding: const EdgeInsets.only(right: 8),
+                      child: ChoiceChip(
+                        label: Text('$y'),
+                        selected: filterYear == y,
+                        onSelected: (_) => onYearChanged(y),
+                      ),
+                    )),
+              ],
+            ),
+          ),
+        ),
+        // Trip list
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: filtered.length,
+            itemBuilder: (context, i) {
+              final e = filtered[i];
+              return Card(
+                margin: const EdgeInsets.only(bottom: 12),
+                child: ListTile(
+                  leading: Text(e.type.emoji,
+                      style: const TextStyle(fontSize: 28)),
+                  title: Text(e.destination,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
+                  subtitle: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        '${e.startDate.month}/${e.startDate.day} – ${e.endDate.month}/${e.endDate.day}/${e.endDate.year}  •  ${e.durationDays}d',
+                      ),
+                      if (e.country != null) Text('🏳️ ${e.country}'),
+                      if (e.rating != null)
+                        Text('${e.rating!.emoji} ${e.rating!.label}'),
+                      if (e.totalCost != null)
+                        Text('💰 \$${e.totalCost!.toStringAsFixed(0)}'),
+                      if (e.highlights.isNotEmpty)
+                        Text('✨ ${e.highlights.join(", ")}',
+                            maxLines: 1, overflow: TextOverflow.ellipsis),
+                    ],
+                  ),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline, color: Colors.red),
+                    onPressed: () => onDelete(e.id),
+                  ),
+                  isThreeLine: true,
+                ),
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ─── Stats Tab ─────────────────────────────────────────────────────────
+
+class _StatsTab extends StatelessWidget {
+  final List<TravelEntry> entries;
+  final TravelLogService service;
+  const _StatsTab({required this.entries, required this.service});
+
+  @override
+  Widget build(BuildContext context) {
+    final stats = service.computeStats(entries);
+    if (stats.totalTrips == 0) {
+      return const Center(
+        child: Text('Log some trips to see stats!',
+            style: TextStyle(color: Colors.grey)),
+      );
+    }
+
+    final monthlyCosts = service.getMonthlyCosts(entries);
+    final maxCost = monthlyCosts.isEmpty
+        ? 1.0
+        : monthlyCosts.map((m) => m.total).reduce((a, b) => a > b ? a : b);
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        // Summary cards
+        Row(
+          children: [
+            _StatCard('🌍', 'Trips', '${stats.totalTrips}'),
+            const SizedBox(width: 12),
+            _StatCard('📅', 'Days', '${stats.totalDays}'),
+            const SizedBox(width: 12),
+            _StatCard('🗺️', 'Countries', '${stats.countriesVisited}'),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            _StatCard('💰', 'Total Spent',
+                '\$${stats.totalSpent.toStringAsFixed(0)}'),
+            const SizedBox(width: 12),
+            _StatCard('⭐', 'Avg Rating',
+                stats.avgRating > 0
+                    ? stats.avgRating.toStringAsFixed(1)
+                    : '—'),
+            const SizedBox(width: 12),
+            _StatCard('🏆', 'Longest',
+                '${stats.longestTripDays}d'),
+          ],
+        ),
+        const SizedBox(height: 24),
+        // Trip type breakdown
+        const Text('By Trip Type',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        ...stats.typeBreakdown.entries.map((e) {
+          final pct = e.value / stats.totalTrips;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                SizedBox(
+                    width: 100,
+                    child: Text('${e.key.emoji} ${e.key.label}')),
+                Expanded(
+                  child: LinearProgressIndicator(
+                    value: pct,
+                    minHeight: 16,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text('${e.value}'),
+              ],
+            ),
+          );
+        }),
+        const SizedBox(height: 24),
+        // Transport breakdown
+        const Text('By Transport',
+            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+        const SizedBox(height: 8),
+        ...stats.transportBreakdown.entries.map((e) {
+          final pct = e.value / stats.totalTrips;
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 8),
+            child: Row(
+              children: [
+                SizedBox(
+                    width: 100,
+                    child: Text('${e.key.emoji} ${e.key.label}')),
+                Expanded(
+                  child: LinearProgressIndicator(
+                    value: pct,
+                    minHeight: 16,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text('${e.value}'),
+              ],
+            ),
+          );
+        }),
+        if (monthlyCosts.isNotEmpty) ...[
+          const SizedBox(height: 24),
+          const Text('Monthly Spending',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          ...monthlyCosts.map((m) {
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 6),
+              child: Row(
+                children: [
+                  SizedBox(width: 80, child: Text(m.label)),
+                  Expanded(
+                    child: LinearProgressIndicator(
+                      value: m.total / maxCost,
+                      minHeight: 14,
+                      borderRadius: BorderRadius.circular(7),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text('\$${m.total.toStringAsFixed(0)}'),
+                ],
+              ),
+            );
+          }),
+        ],
+      ],
+    );
+  }
+}
+
+class _StatCard extends StatelessWidget {
+  final String emoji;
+  final String label;
+  final String value;
+  const _StatCard(this.emoji, this.label, this.value);
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Card(
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            children: [
+              Text(emoji, style: const TextStyle(fontSize: 24)),
+              const SizedBox(height: 4),
+              Text(value,
+                  style: const TextStyle(
+                      fontSize: 20, fontWeight: FontWeight.bold)),
+              Text(label,
+                  style: const TextStyle(fontSize: 12, color: Colors.grey)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── Insights Tab ──────────────────────────────────────────────────────
+
+class _InsightsTab extends StatelessWidget {
+  final List<TravelEntry> entries;
+  final TravelLogService service;
+  const _InsightsTab({required this.entries, required this.service});
+
+  @override
+  Widget build(BuildContext context) {
+    final insights = service.generateInsights(entries);
+    final upcoming = service.getUpcoming(entries);
+
+    if (insights.isEmpty && upcoming.isEmpty) {
+      return const Center(
+        child: Text('Log some trips to see insights!',
+            style: TextStyle(color: Colors.grey)),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        if (upcoming.isNotEmpty) ...[
+          const Text('🗓️ Upcoming Trips',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          ...upcoming.map((e) => Card(
+                child: ListTile(
+                  leading: Text(e.type.emoji,
+                      style: const TextStyle(fontSize: 24)),
+                  title: Text(e.destination),
+                  subtitle: Text(
+                    '${e.startDate.month}/${e.startDate.day}/${e.startDate.year} • ${e.durationDays} days',
+                  ),
+                ),
+              )),
+          const SizedBox(height: 24),
+        ],
+        if (insights.isNotEmpty) ...[
+          const Text('📊 Travel Insights',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          const SizedBox(height: 8),
+          ...insights.map((i) => Card(
+                child: ListTile(
+                  leading: Text(i.emoji,
+                      style: const TextStyle(fontSize: 24)),
+                  title: Text(i.title),
+                  subtitle: Text(i.value),
+                ),
+              )),
+        ],
+      ],
+    );
+  }
+}

--- a/test/travel_log_test.dart
+++ b/test/travel_log_test.dart
@@ -1,0 +1,439 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:everything/models/travel_entry.dart';
+import 'package:everything/core/services/travel_log_service.dart';
+
+void main() {
+  const service = TravelLogService();
+  final now = DateTime.now();
+
+  TravelEntry _make({
+    String id = 't1',
+    String destination = 'Tokyo',
+    String? country = 'Japan',
+    DateTime? startDate,
+    DateTime? endDate,
+    TripType type = TripType.leisure,
+    TripTransport transport = TripTransport.flight,
+    TripRating? rating,
+    double? totalCost,
+    List<String> highlights = const [],
+    bool isCompleted = true,
+  }) {
+    return TravelEntry(
+      id: id,
+      destination: destination,
+      country: country,
+      startDate: startDate ?? now.subtract(const Duration(days: 10)),
+      endDate: endDate ?? now.subtract(const Duration(days: 5)),
+      type: type,
+      transport: transport,
+      rating: rating,
+      totalCost: totalCost,
+      highlights: highlights,
+      isCompleted: isCompleted,
+    );
+  }
+
+  // ─── Model Tests ──────────────────────────────────────────────────
+
+  group('TravelEntry model', () {
+    test('durationDays calculates correctly', () {
+      final e = _make(
+        startDate: DateTime(2026, 3, 1),
+        endDate: DateTime(2026, 3, 5),
+      );
+      expect(e.durationDays, 5);
+    });
+
+    test('durationDays is at least 1 for same-day trip', () {
+      final d = DateTime(2026, 3, 1);
+      final e = _make(startDate: d, endDate: d);
+      expect(e.durationDays, 1);
+    });
+
+    test('costPerDay is null without totalCost', () {
+      final e = _make();
+      expect(e.costPerDay, isNull);
+    });
+
+    test('costPerDay calculates correctly', () {
+      final e = _make(
+        startDate: DateTime(2026, 3, 1),
+        endDate: DateTime(2026, 3, 5),
+        totalCost: 500,
+      );
+      expect(e.costPerDay, 100.0);
+    });
+
+    test('isUpcoming for future trip', () {
+      final e = _make(
+        startDate: now.add(const Duration(days: 10)),
+        endDate: now.add(const Duration(days: 15)),
+        isCompleted: false,
+      );
+      expect(e.isUpcoming, true);
+    });
+
+    test('isUpcoming false for past trip', () {
+      final e = _make();
+      expect(e.isUpcoming, false);
+    });
+
+    test('copyWith preserves fields', () {
+      final e = _make(totalCost: 1200, rating: TripRating.great);
+      final copy = e.copyWith(destination: 'Osaka');
+      expect(copy.destination, 'Osaka');
+      expect(copy.totalCost, 1200);
+      expect(copy.rating, TripRating.great);
+      expect(copy.id, e.id);
+    });
+
+    test('copyWith overrides specified fields', () {
+      final e = _make(type: TripType.business);
+      final copy = e.copyWith(type: TripType.adventure);
+      expect(copy.type, TripType.adventure);
+    });
+  });
+
+  group('TripType enum', () {
+    test('all types have label and emoji', () {
+      for (final t in TripType.values) {
+        expect(t.label.isNotEmpty, true);
+        expect(t.emoji.isNotEmpty, true);
+      }
+    });
+  });
+
+  group('TripTransport enum', () {
+    test('all transports have label and emoji', () {
+      for (final t in TripTransport.values) {
+        expect(t.label.isNotEmpty, true);
+        expect(t.emoji.isNotEmpty, true);
+      }
+    });
+  });
+
+  group('TripRating enum', () {
+    test('ratings are 1 through 5', () {
+      final values = TripRating.values.map((r) => r.value).toList()..sort();
+      expect(values, [1, 2, 3, 4, 5]);
+    });
+  });
+
+  // ─── Service Tests ────────────────────────────────────────────────
+
+  group('computeStats', () {
+    test('empty list returns zeroes', () {
+      final stats = service.computeStats([]);
+      expect(stats.totalTrips, 0);
+      expect(stats.totalDays, 0);
+      expect(stats.totalSpent, 0);
+      expect(stats.avgRating, 0);
+    });
+
+    test('counts total trips and days', () {
+      final entries = [
+        _make(
+          id: 't1',
+          startDate: DateTime(2026, 1, 1),
+          endDate: DateTime(2026, 1, 5),
+        ),
+        _make(
+          id: 't2',
+          startDate: DateTime(2026, 2, 10),
+          endDate: DateTime(2026, 2, 12),
+        ),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.totalTrips, 2);
+      expect(stats.totalDays, 8); // 5 + 3
+    });
+
+    test('calculates average rating', () {
+      final entries = [
+        _make(id: 't1', rating: TripRating.amazing),
+        _make(id: 't2', rating: TripRating.good),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.avgRating, 4.0); // (5+3)/2
+    });
+
+    test('excludes non-completed trips', () {
+      final entries = [
+        _make(id: 't1'),
+        _make(id: 't2', isCompleted: false),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.totalTrips, 1);
+    });
+
+    test('counts unique countries', () {
+      final entries = [
+        _make(id: 't1', country: 'Japan'),
+        _make(id: 't2', country: 'Japan'),
+        _make(id: 't3', country: 'France'),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.countriesVisited, 2);
+    });
+
+    test('counts unique cities', () {
+      final entries = [
+        _make(id: 't1', destination: 'Tokyo'),
+        _make(id: 't2', destination: 'Tokyo'),
+        _make(id: 't3', destination: 'Paris'),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.citiesVisited, 2);
+    });
+
+    test('sums total cost', () {
+      final entries = [
+        _make(id: 't1', totalCost: 1000),
+        _make(id: 't2', totalCost: 500),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.totalSpent, 1500);
+    });
+
+    test('finds longest trip', () {
+      final entries = [
+        _make(
+          id: 't1',
+          startDate: DateTime(2026, 1, 1),
+          endDate: DateTime(2026, 1, 3),
+        ),
+        _make(
+          id: 't2',
+          startDate: DateTime(2026, 2, 1),
+          endDate: DateTime(2026, 2, 10),
+        ),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.longestTripDays, 10);
+    });
+
+    test('identifies favorite destination', () {
+      final entries = [
+        _make(id: 't1', destination: 'Tokyo'),
+        _make(id: 't2', destination: 'Tokyo'),
+        _make(id: 't3', destination: 'Paris'),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.favoriteDestination, 'Tokyo');
+    });
+
+    test('tracks type breakdown', () {
+      final entries = [
+        _make(id: 't1', type: TripType.business),
+        _make(id: 't2', type: TripType.leisure),
+        _make(id: 't3', type: TripType.business),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.typeBreakdown[TripType.business], 2);
+      expect(stats.typeBreakdown[TripType.leisure], 1);
+    });
+
+    test('tracks transport breakdown', () {
+      final entries = [
+        _make(id: 't1', transport: TripTransport.flight),
+        _make(id: 't2', transport: TripTransport.train),
+        _make(id: 't3', transport: TripTransport.flight),
+      ];
+      final stats = service.computeStats(entries);
+      expect(stats.transportBreakdown[TripTransport.flight], 2);
+    });
+  });
+
+  group('getMonthlyCosts', () {
+    test('empty list returns empty', () {
+      expect(service.getMonthlyCosts([]), isEmpty);
+    });
+
+    test('groups by month', () {
+      final entries = [
+        _make(
+          id: 't1',
+          startDate: DateTime(2026, 1, 5),
+          endDate: DateTime(2026, 1, 10),
+          totalCost: 800,
+        ),
+        _make(
+          id: 't2',
+          startDate: DateTime(2026, 1, 20),
+          endDate: DateTime(2026, 1, 22),
+          totalCost: 200,
+        ),
+        _make(
+          id: 't3',
+          startDate: DateTime(2026, 3, 1),
+          endDate: DateTime(2026, 3, 5),
+          totalCost: 600,
+        ),
+      ];
+      final costs = service.getMonthlyCosts(entries);
+      expect(costs.length, 2);
+      expect(costs[0].month, 1);
+      expect(costs[0].total, 1000);
+      expect(costs[0].tripCount, 2);
+      expect(costs[1].month, 3);
+      expect(costs[1].total, 600);
+    });
+
+    test('excludes entries without cost', () {
+      final entries = [
+        _make(id: 't1', totalCost: 500,
+            startDate: DateTime(2026, 2, 1), endDate: DateTime(2026, 2, 3)),
+        _make(id: 't2',
+            startDate: DateTime(2026, 2, 10), endDate: DateTime(2026, 2, 12)),
+      ];
+      final costs = service.getMonthlyCosts(entries);
+      expect(costs.length, 1);
+      expect(costs[0].total, 500);
+      expect(costs[0].tripCount, 1);
+    });
+
+    test('sorted chronologically', () {
+      final entries = [
+        _make(id: 't1', totalCost: 100,
+            startDate: DateTime(2026, 6, 1), endDate: DateTime(2026, 6, 3)),
+        _make(id: 't2', totalCost: 200,
+            startDate: DateTime(2026, 2, 1), endDate: DateTime(2026, 2, 3)),
+      ];
+      final costs = service.getMonthlyCosts(entries);
+      expect(costs[0].month, 2);
+      expect(costs[1].month, 6);
+    });
+  });
+
+  group('getUpcoming', () {
+    test('returns only future, non-completed trips', () {
+      final entries = [
+        _make(id: 't1'), // past completed
+        _make(
+          id: 't2',
+          startDate: now.add(const Duration(days: 5)),
+          endDate: now.add(const Duration(days: 10)),
+          isCompleted: false,
+        ),
+        _make(
+          id: 't3',
+          startDate: now.add(const Duration(days: 20)),
+          endDate: now.add(const Duration(days: 25)),
+          isCompleted: false,
+        ),
+      ];
+      final upcoming = service.getUpcoming(entries);
+      expect(upcoming.length, 2);
+      expect(upcoming[0].id, 't2'); // earliest first
+    });
+
+    test('empty when all completed', () {
+      final entries = [_make(id: 't1'), _make(id: 't2')];
+      expect(service.getUpcoming(entries), isEmpty);
+    });
+  });
+
+  group('getByYear', () {
+    test('filters by year', () {
+      final entries = [
+        _make(id: 't1', startDate: DateTime(2025, 5, 1),
+            endDate: DateTime(2025, 5, 5)),
+        _make(id: 't2', startDate: DateTime(2026, 1, 1),
+            endDate: DateTime(2026, 1, 3)),
+        _make(id: 't3', startDate: DateTime(2026, 6, 1),
+            endDate: DateTime(2026, 6, 5)),
+      ];
+      final y2026 = service.getByYear(entries, 2026);
+      expect(y2026.length, 2);
+    });
+
+    test('returns most recent first', () {
+      final entries = [
+        _make(id: 't1', startDate: DateTime(2026, 1, 1),
+            endDate: DateTime(2026, 1, 3)),
+        _make(id: 't2', startDate: DateTime(2026, 6, 1),
+            endDate: DateTime(2026, 6, 5)),
+      ];
+      final result = service.getByYear(entries, 2026);
+      expect(result[0].id, 't2');
+    });
+  });
+
+  group('getYears', () {
+    test('returns unique years descending', () {
+      final entries = [
+        _make(id: 't1', startDate: DateTime(2024, 1, 1),
+            endDate: DateTime(2024, 1, 3)),
+        _make(id: 't2', startDate: DateTime(2026, 1, 1),
+            endDate: DateTime(2026, 1, 3)),
+        _make(id: 't3', startDate: DateTime(2025, 1, 1),
+            endDate: DateTime(2025, 1, 3)),
+      ];
+      expect(service.getYears(entries), [2026, 2025, 2024]);
+    });
+  });
+
+  group('generateInsights', () {
+    test('empty for no entries', () {
+      expect(service.generateInsights([]), isEmpty);
+    });
+
+    test('generates insights for trips', () {
+      final entries = [
+        _make(id: 't1', totalCost: 1000, rating: TripRating.great,
+            country: 'Japan'),
+        _make(id: 't2', totalCost: 800, rating: TripRating.amazing,
+            destination: 'Paris', country: 'France'),
+      ];
+      final insights = service.generateInsights(entries);
+      expect(insights.length, greaterThanOrEqualTo(4));
+      expect(insights.any((i) => i.title == 'Total Travel'), true);
+      expect(insights.any((i) => i.title == 'Countries'), true);
+      expect(insights.any((i) => i.title == 'Avg Rating'), true);
+      expect(insights.any((i) => i.title == 'Avg Trip Cost'), true);
+    });
+
+    test('includes preferred transport', () {
+      final entries = [
+        _make(id: 't1', transport: TripTransport.train),
+        _make(id: 't2', transport: TripTransport.train),
+        _make(id: 't3', transport: TripTransport.flight),
+      ];
+      final insights = service.generateInsights(entries);
+      final transportInsight = insights.firstWhere(
+          (i) => i.title == 'Preferred Transport',
+          orElse: () => const TravelInsight(
+              title: '', value: '', emoji: ''));
+      expect(transportInsight.value, 'Train');
+    });
+
+    test('includes most visited destination', () {
+      final entries = [
+        _make(id: 't1', destination: 'Tokyo'),
+        _make(id: 't2', destination: 'Tokyo'),
+        _make(id: 't3', destination: 'Paris'),
+      ];
+      final insights = service.generateInsights(entries);
+      final mostVisited = insights.firstWhere(
+          (i) => i.title == 'Most Visited',
+          orElse: () => const TravelInsight(
+              title: '', value: '', emoji: ''));
+      expect(mostVisited.value, 'Tokyo');
+    });
+  });
+
+  group('TravelMonthlyCost', () {
+    test('label formats correctly', () {
+      const cost = TravelMonthlyCost(
+          year: 2026, month: 3, total: 1500, tripCount: 2);
+      expect(cost.label, 'Mar 2026');
+    });
+
+    test('clamps invalid months', () {
+      const cost = TravelMonthlyCost(
+          year: 2026, month: 0, total: 0, tripCount: 0);
+      expect(cost.label, 'Jan 2026'); // clamps to 1
+    });
+  });
+}


### PR DESCRIPTION
4-tab travel logging UI:
- **Log**: Destination, country, date range, 8 trip types, 7 transport modes, 5-star rating, cost tracking, highlights list, notes
- **Trips**: Chronological list with year filter chips, trip cards with type/date/rating/cost/highlights, swipe-to-delete
- **Stats**: Summary cards (trips/days/countries/cost/rating/longest), type + transport breakdowns with progress bars, monthly spending chart
- **Insights**: Upcoming trips timeline, auto-generated insights (total travel, countries explored, avg rating, avg cost, longest trip, most visited destination, preferred transport)

+1,549 lines across model, service, screen, and 35 tests.