### PR TITLE
feat: add ServicePersistence mixin for 5 key services

### DIFF
--- a/lib/core/services/contact_tracker_service.dart
+++ b/lib/core/services/contact_tracker_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import '../../models/contact.dart';
+import 'service_persistence.dart';
 
 /// Statistics for a relationship category.
 class CategoryStats {
@@ -105,7 +106,7 @@ class ContactReport {
 }
 
 /// Service for managing contacts, interactions, and relationship health.
-class ContactTrackerService {
+class ContactTrackerService with ServicePersistence {
   /// Maximum contacts allowed via [loadJson] to prevent memory exhaustion
   /// from corrupted or malicious import data (CWE-770).
   static const int maxImportEntries = 50000;
@@ -113,6 +114,28 @@ class ContactTrackerService {
   final List<Contact> _contacts = [];
   int _nextId = 1;
   int _nextInteractionId = 1;
+
+  @override
+  String get storageKey => 'contact_tracker_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'contacts': _contacts.map((c) => c.toJson()).toList(),
+        'nextId': _nextId,
+        'nextInteractionId': _nextInteractionId,
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _contacts.clear();
+    if (json['contacts'] != null) {
+      _contacts.addAll(
+        (json['contacts'] as List).map((c) => Contact.fromJson(c as Map<String, dynamic>)),
+      );
+    }
+    _nextId = json['nextId'] as int? ?? _contacts.length + 1;
+    _nextInteractionId = json['nextInteractionId'] as int? ?? 1;
+  }
 
   List<Contact> get contacts => List.unmodifiable(_contacts);
 

--- a/lib/core/services/expense_tracker_service.dart
+++ b/lib/core/services/expense_tracker_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 import '../../models/expense_entry.dart';
+import 'service_persistence.dart';
 
 /// Configuration for expense tracking budgets.
 class BudgetConfig {
@@ -234,9 +235,40 @@ class ExpenseReport {
 }
 
 /// Expense tracker service with budgeting, analytics, and insights.
-class ExpenseTrackerService {
+class ExpenseTrackerService with ServicePersistence {
   final List<ExpenseEntry> _entries = [];
   BudgetConfig _config;
+
+  @override
+  String get storageKey => 'expense_tracker_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'entries': _entries.map((e) => e.toJson()).toList(),
+        'config': {
+          'monthlyBudget': _config.monthlyBudget,
+          'alertThreshold': _config.alertThreshold,
+          'currencySymbol': _config.currencySymbol,
+        },
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _entries.clear();
+    if (json['entries'] != null) {
+      _entries.addAll(
+        (json['entries'] as List).map((e) => ExpenseEntry.fromJson(e as Map<String, dynamic>)),
+      );
+    }
+    if (json['config'] != null) {
+      final c = json['config'] as Map<String, dynamic>;
+      _config = BudgetConfig(
+        monthlyBudget: (c['monthlyBudget'] as num?)?.toDouble() ?? 3000.0,
+        alertThreshold: (c['alertThreshold'] as num?)?.toDouble() ?? 0.8,
+        currencySymbol: c['currencySymbol'] as String? ?? '\$',
+      );
+    }
+  }
 
   ExpenseTrackerService({BudgetConfig? config})
       : _config = config ?? const BudgetConfig();

--- a/lib/core/services/goal_tracker_service.dart
+++ b/lib/core/services/goal_tracker_service.dart
@@ -2,6 +2,7 @@
 /// progress tracking, deadlines, and category-based organization.
 
 import '../../models/goal.dart';
+import 'service_persistence.dart';
 
 /// Summary stats for goal tracking.
 class GoalSummary {
@@ -23,8 +24,26 @@ class GoalSummary {
 }
 
 /// Main service for goal tracking.
-class GoalTrackerService {
+class GoalTrackerService with ServicePersistence {
   final List<Goal> _goals;
+
+  @override
+  String get storageKey => 'goal_tracker_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'goals': _goals.map((g) => g.toJson()).toList(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _goals.clear();
+    if (json['goals'] != null) {
+      _goals.addAll(
+        (json['goals'] as List).map((g) => Goal.fromJson(g as Map<String, dynamic>)),
+      );
+    }
+  }
 
   GoalTrackerService({List<Goal>? goals}) : _goals = goals ?? [];
 

--- a/lib/core/services/gratitude_journal_service.dart
+++ b/lib/core/services/gratitude_journal_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 import '../../models/gratitude_entry.dart';
+import 'service_persistence.dart';
 
 /// Daily gratitude summary.
 class DailyGratitudeSummary {
@@ -94,9 +95,29 @@ class GratitudeReport {
 
 /// Gratitude Journal Service — tracks daily gratitude entries with categories,
 /// intensity, tags, favorites, streaks, weekly reports, insights, and prompts.
-class GratitudeJournalService {
+class GratitudeJournalService with ServicePersistence {
   final List<GratitudeEntry> _entries = [];
   int _idCounter = 0;
+
+  @override
+  String get storageKey => 'gratitude_journal_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'entries': _entries.map((e) => e.toJson()).toList(),
+        'idCounter': _idCounter,
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _entries.clear();
+    if (json['entries'] != null) {
+      _entries.addAll(
+        (json['entries'] as List).map((e) => GratitudeEntry.fromJson(e as Map<String, dynamic>)),
+      );
+    }
+    _idCounter = json['idCounter'] as int? ?? _entries.length;
+  }
 
   // --- CRUD ---
 

--- a/lib/core/services/habit_tracker_service.dart
+++ b/lib/core/services/habit_tracker_service.dart
@@ -11,6 +11,7 @@
 /// - Habit archiving (soft delete)
 
 import '../../models/habit.dart';
+import 'service_persistence.dart';
 
 /// Stats for a single habit over a date range.
 class HabitStats {
@@ -95,9 +96,34 @@ class WeeklyHabitSummary {
 }
 
 /// Main service for habit tracking.
-class HabitTrackerService {
+class HabitTrackerService with ServicePersistence {
   final List<Habit> _habits;
   final List<HabitCompletion> _completions;
+
+  @override
+  String get storageKey => 'habit_tracker_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'habits': _habits.map((h) => h.toJson()).toList(),
+        'completions': _completions.map((c) => c.toJson()).toList(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _habits.clear();
+    _completions.clear();
+    if (json['habits'] != null) {
+      _habits.addAll(
+        (json['habits'] as List).map((h) => Habit.fromJson(h as Map<String, dynamic>)),
+      );
+    }
+    if (json['completions'] != null) {
+      _completions.addAll(
+        (json['completions'] as List).map((c) => HabitCompletion.fromJson(c as Map<String, dynamic>)),
+      );
+    }
+  }
 
   HabitTrackerService({
     List<Habit>? habits,

--- a/lib/core/services/service_persistence.dart
+++ b/lib/core/services/service_persistence.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Mixin for adding SharedPreferences-based persistence to stateful services.
+///
+/// Services that hold in-memory state (lists, maps) can use this mixin to
+/// automatically save/restore their data across app restarts.
+///
+/// Usage:
+/// ```dart
+/// class MyService with ServicePersistence {
+///   @override
+///   String get storageKey => 'my_service_data';
+///
+///   @override
+///   Map<String, dynamic> toStorageJson() => { 'items': _items.map((e) => e.toJson()).toList() };
+///
+///   @override
+///   void fromStorageJson(Map<String, dynamic> json) {
+///     _items = (json['items'] as List).map((e) => Item.fromJson(e)).toList();
+///   }
+/// }
+/// ```
+mixin ServicePersistence {
+  /// Unique key for SharedPreferences storage.
+  String get storageKey;
+
+  /// Serialize service state to JSON-compatible map.
+  Map<String, dynamic> toStorageJson();
+
+  /// Restore service state from a JSON-compatible map.
+  void fromStorageJson(Map<String, dynamic> json);
+
+  bool _persInitialized = false;
+
+  /// Whether persistence has been initialized (data loaded).
+  bool get isInitialized => _persInitialized;
+
+  /// Load state from SharedPreferences. Call once at startup or before first use.
+  Future<bool> loadState() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        final json = jsonDecode(data) as Map<String, dynamic>;
+        fromStorageJson(json);
+        _persInitialized = true;
+        return true;
+      } catch (_) {
+        // Corrupted data — start fresh
+        _persInitialized = true;
+        return false;
+      }
+    }
+    _persInitialized = true;
+    return false;
+  }
+
+  /// Save current state to SharedPreferences.
+  Future<void> saveState() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(storageKey, jsonEncode(toStorageJson()));
+  }
+
+  /// Clear persisted state.
+  Future<void> clearState() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(storageKey);
+  }
+}


### PR DESCRIPTION
## Summary

Partial fix for #42 — adds persistence to 5 of the 39 services that lose data on app restart.

### New: \ServicePersistence\ mixin

A reusable mixin (\lib/core/services/service_persistence.dart\) providing SharedPreferences-based state persistence:

- \loadState()\ — restore from SharedPreferences (call once at startup)
- \saveState()\ — persist current state
- \clearState()\ — remove persisted data
- Handles JSON corruption gracefully (starts fresh on decode errors)

### Services updated

| Service | Data persisted |
|---------|---------------|
| **HabitTrackerService** | Habits + completions |
| **ExpenseTrackerService** | Expense entries + budget config |
| **GoalTrackerService** | Goals + milestones |
| **GratitudeJournalService** | Entries + ID counter |
| **ContactTrackerService** | Contacts + interaction IDs |

### Usage

Each service now has the mixin applied. Callers need to:
1. Call \wait service.loadState()\ during app initialization
2. Call \wait service.saveState()\ after mutations

### Next steps

The remaining 34 services can adopt the same pattern incrementally. The mixin is generic and works with any service that can serialize its state to JSON.