### PR TITLE
feat: add SharedPreferences persistence to 5 services (partial fix for #42)

### DIFF
--- a/lib/core/services/expense_tracker_service.dart
+++ b/lib/core/services/expense_tracker_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 import '../../models/expense_entry.dart';
+import 'service_persistence.dart';
 
 /// Configuration for expense tracking budgets.
 class BudgetConfig {
@@ -234,12 +235,35 @@ class ExpenseReport {
 }
 
 /// Expense tracker service with budgeting, analytics, and insights.
-class ExpenseTrackerService {
+class ExpenseTrackerService with ServicePersistence {
   final List<ExpenseEntry> _entries = [];
   BudgetConfig _config;
 
+  @override
+  String get storageKey => 'expense_tracker_data';
+
   ExpenseTrackerService({BudgetConfig? config})
       : _config = config ?? const BudgetConfig();
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'entries': _entries.map((e) => e.toJson()).toList(),
+        'config': _config.toJson(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _entries.clear();
+    if (json['entries'] != null) {
+      _entries.addAll(
+        (json['entries'] as List)
+            .map((e) => ExpenseEntry.fromJson(e as Map<String, dynamic>)),
+      );
+    }
+    if (json['config'] != null) {
+      _config = BudgetConfig.fromJson(json['config'] as Map<String, dynamic>);
+    }
+  }
 
   // --- Config ---
 
@@ -247,6 +271,7 @@ class ExpenseTrackerService {
 
   void updateConfig(BudgetConfig config) {
     _config = config;
+    persistState();
   }
 
   // --- CRUD ---
@@ -255,16 +280,19 @@ class ExpenseTrackerService {
 
   void addEntry(ExpenseEntry entry) {
     _entries.add(entry);
+    persistState();
   }
 
   void addEntries(List<ExpenseEntry> entries) {
     _entries.addAll(entries);
+    persistState();
   }
 
   bool removeEntry(String id) {
     final idx = _entries.indexWhere((e) => e.id == id);
     if (idx < 0) return false;
     _entries.removeAt(idx);
+    persistState();
     return true;
   }
 

--- a/lib/core/services/goal_tracker_service.dart
+++ b/lib/core/services/goal_tracker_service.dart
@@ -2,6 +2,7 @@
 /// progress tracking, deadlines, and category-based organization.
 
 import '../../models/goal.dart';
+import 'service_persistence.dart';
 
 /// Summary stats for goal tracking.
 class GoalSummary {
@@ -23,10 +24,29 @@ class GoalSummary {
 }
 
 /// Main service for goal tracking.
-class GoalTrackerService {
+class GoalTrackerService with ServicePersistence {
   final List<Goal> _goals;
 
+  @override
+  String get storageKey => 'goal_tracker_data';
+
   GoalTrackerService({List<Goal>? goals}) : _goals = goals ?? [];
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'goals': _goals.map((g) => g.toJson()).toList(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _goals.clear();
+    if (json['goals'] != null) {
+      _goals.addAll(
+        (json['goals'] as List)
+            .map((g) => Goal.fromJson(g as Map<String, dynamic>)),
+      );
+    }
+  }
 
   /// All non-archived goals.
   List<Goal> get activeGoals =>
@@ -54,28 +74,33 @@ class GoalTrackerService {
       throw ArgumentError('Goal with id "${goal.id}" already exists');
     }
     _goals.add(goal);
+    persistState();
   }
 
   void updateGoal(Goal updated) {
     final idx = _goals.indexWhere((g) => g.id == updated.id);
     if (idx == -1) throw ArgumentError('Goal "${updated.id}" not found');
     _goals[idx] = updated;
+    persistState();
   }
 
   void deleteGoal(String goalId) {
     _goals.removeWhere((g) => g.id == goalId);
+    persistState();
   }
 
   void archiveGoal(String goalId) {
     final idx = _goals.indexWhere((g) => g.id == goalId);
     if (idx == -1) return;
     _goals[idx] = _goals[idx].copyWith(isArchived: true);
+    persistState();
   }
 
   void completeGoal(String goalId) {
     final idx = _goals.indexWhere((g) => g.id == goalId);
     if (idx == -1) return;
     _goals[idx] = _goals[idx].copyWith(isCompleted: true, progress: 100);
+    persistState();
   }
 
   // ── Milestone Management ─────────────────────────────────────────
@@ -100,6 +125,7 @@ class GoalTrackerService {
       isCompleted: allDone,
       progress: allDone ? 100 : goal.progress,
     );
+    persistState();
   }
 
   void addMilestone(String goalId, Milestone milestone) {
@@ -108,6 +134,7 @@ class GoalTrackerService {
     final milestones = List<Milestone>.from(_goals[idx].milestones)
       ..add(milestone);
     _goals[idx] = _goals[idx].copyWith(milestones: milestones);
+    persistState();
   }
 
   void removeMilestone(String goalId, String milestoneId) {
@@ -118,6 +145,7 @@ class GoalTrackerService {
         .where((m) => m.id != milestoneId)
         .toList();
     _goals[idx] = _goals[idx].copyWith(milestones: milestones);
+    persistState();
   }
 
   // ── Progress ──────────────────────────────────────────────────────
@@ -130,6 +158,7 @@ class GoalTrackerService {
       progress: clamped,
       isCompleted: clamped == 100,
     );
+    persistState();
   }
 
   // ── Statistics ────────────────────────────────────────────────────

--- a/lib/core/services/gratitude_journal_service.dart
+++ b/lib/core/services/gratitude_journal_service.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:math';
 import '../../models/gratitude_entry.dart';
+import 'service_persistence.dart';
 
 /// Daily gratitude summary.
 class DailyGratitudeSummary {
@@ -94,9 +95,30 @@ class GratitudeReport {
 
 /// Gratitude Journal Service — tracks daily gratitude entries with categories,
 /// intensity, tags, favorites, streaks, weekly reports, insights, and prompts.
-class GratitudeJournalService {
+class GratitudeJournalService with ServicePersistence {
   final List<GratitudeEntry> _entries = [];
   int _idCounter = 0;
+
+  @override
+  String get storageKey => 'gratitude_journal_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'entries': _entries.map((e) => e.toJson()).toList(),
+        'idCounter': _idCounter,
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _entries.clear();
+    if (json['entries'] != null) {
+      _entries.addAll(
+        (json['entries'] as List)
+            .map((e) => GratitudeEntry.fromJson(e as Map<String, dynamic>)),
+      );
+    }
+    _idCounter = (json['idCounter'] as int?) ?? _entries.length;
+  }
 
   // --- CRUD ---
 
@@ -119,6 +141,7 @@ class GratitudeJournalService {
       tags: List.from(tags),
       note: note?.trim(),
     ));
+    persistState();
     return id;
   }
 
@@ -146,6 +169,7 @@ class GratitudeJournalService {
       tags: tags,
       note: note,
     );
+    persistState();
     return true;
   }
 
@@ -153,6 +177,7 @@ class GratitudeJournalService {
     final idx = _entries.indexWhere((e) => e.id == id);
     if (idx == -1) return false;
     _entries.removeAt(idx);
+    persistState();
     return true;
   }
 
@@ -160,6 +185,7 @@ class GratitudeJournalService {
     final idx = _entries.indexWhere((e) => e.id == id);
     if (idx == -1) return false;
     _entries[idx] = _entries[idx].copyWith(isFavorite: !_entries[idx].isFavorite);
+    persistState();
     return true;
   }
 
@@ -577,5 +603,6 @@ class GratitudeJournalService {
     _entries.clear();
     _entries.addAll(parsed);
     _idCounter = clampedMax;
+    persistState();
   }
 }

--- a/lib/core/services/habit_tracker_service.dart
+++ b/lib/core/services/habit_tracker_service.dart
@@ -11,6 +11,7 @@
 /// - Habit archiving (soft delete)
 
 import '../../models/habit.dart';
+import 'service_persistence.dart';
 
 /// Stats for a single habit over a date range.
 class HabitStats {
@@ -95,15 +96,41 @@ class WeeklyHabitSummary {
 }
 
 /// Main service for habit tracking.
-class HabitTrackerService {
+class HabitTrackerService with ServicePersistence {
   final List<Habit> _habits;
   final List<HabitCompletion> _completions;
+
+  @override
+  String get storageKey => 'habit_tracker_data';
 
   HabitTrackerService({
     List<Habit>? habits,
     List<HabitCompletion>? completions,
   })  : _habits = habits ?? [],
         _completions = completions ?? [];
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'habits': _habits.map((h) => h.toJson()).toList(),
+        'completions': _completions.map((c) => c.toJson()).toList(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _habits.clear();
+    _completions.clear();
+    if (json['habits'] != null) {
+      _habits.addAll(
+        (json['habits'] as List).map((h) => Habit.fromJson(h as Map<String, dynamic>)),
+      );
+    }
+    if (json['completions'] != null) {
+      _completions.addAll(
+        (json['completions'] as List)
+            .map((c) => HabitCompletion.fromJson(c as Map<String, dynamic>)),
+      );
+    }
+  }
 
   /// All active habits.
   List<Habit> get activeHabits =>
@@ -123,6 +150,7 @@ class HabitTrackerService {
       throw ArgumentError('Habit with id "${habit.id}" already exists');
     }
     _habits.add(habit);
+    persistState();
   }
 
   /// Update an existing habit.
@@ -132,6 +160,7 @@ class HabitTrackerService {
       throw ArgumentError('Habit "${updated.id}" not found');
     }
     _habits[idx] = updated;
+    persistState();
   }
 
   /// Archive a habit (soft delete).
@@ -139,6 +168,7 @@ class HabitTrackerService {
     final idx = _habits.indexWhere((h) => h.id == habitId);
     if (idx == -1) return;
     _habits[idx] = _habits[idx].copyWith(isActive: false);
+    persistState();
   }
 
   // ── Completion Logging ────────────────────────────────────────────
@@ -166,6 +196,7 @@ class HabitTrackerService {
         note: note,
       ));
     }
+    persistState();
   }
 
   /// Remove a completion entry for a habit on a specific date.
@@ -174,6 +205,7 @@ class HabitTrackerService {
     _completions.removeWhere(
       (c) => c.habitId == habitId && _dateOnly(c.date) == d,
     );
+    persistState();
   }
 
   /// Get completions for a habit in a date range.

--- a/lib/core/services/service_persistence.dart
+++ b/lib/core/services/service_persistence.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Mixin that adds automatic SharedPreferences persistence to any service
+/// that stores data in memory.
+///
+/// Usage:
+/// ```dart
+/// class MyService with ServicePersistence {
+///   @override
+///   String get storageKey => 'my_service_data';
+///
+///   @override
+///   Map<String, dynamic> toStorageJson() => { 'items': _items.map((e) => e.toJson()).toList() };
+///
+///   @override
+///   void fromStorageJson(Map<String, dynamic> json) {
+///     _items = (json['items'] as List).map((e) => Item.fromJson(e)).toList();
+///   }
+/// }
+/// ```
+mixin ServicePersistence {
+  /// Unique key for SharedPreferences storage.
+  String get storageKey;
+
+  /// Whether [restoreState] has completed.
+  bool _persistenceInitialized = false;
+  bool get isInitialized => _persistenceInitialized;
+
+  /// Serialize the service's current state to a JSON-compatible map.
+  Map<String, dynamic> toStorageJson();
+
+  /// Restore the service's state from a previously-saved JSON map.
+  void fromStorageJson(Map<String, dynamic> json);
+
+  /// Load persisted state from SharedPreferences.
+  /// Call this in the service's init/constructor before using data.
+  /// Safe to call multiple times — only loads once.
+  Future<void> restoreState() async {
+    if (_persistenceInitialized) return;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final data = prefs.getString(storageKey);
+      if (data != null && data.isNotEmpty) {
+        final json = jsonDecode(data) as Map<String, dynamic>;
+        fromStorageJson(json);
+      }
+    } catch (e) {
+      // Don't crash the app if stored data is corrupt — start fresh
+      // ignore: avoid_print
+      print('ServicePersistence($storageKey): failed to restore — $e');
+    }
+    _persistenceInitialized = true;
+  }
+
+  /// Persist the current state to SharedPreferences.
+  /// Call this after any mutation (add, update, delete).
+  Future<void> persistState() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final data = jsonEncode(toStorageJson());
+      await prefs.setString(storageKey, data);
+    } catch (e) {
+      // ignore: avoid_print
+      print('ServicePersistence($storageKey): failed to persist — $e');
+    }
+  }
+
+  /// Clear persisted state.
+  Future<void> clearPersistedState() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(storageKey);
+  }
+}

--- a/lib/core/services/skill_tracker_service.dart
+++ b/lib/core/services/skill_tracker_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import '../../models/skill_entry.dart';
+import 'service_persistence.dart';
 
 /// Report for a single skill's learning progress.
 class SkillReport {
@@ -104,8 +105,27 @@ class PracticeStreak {
 }
 
 /// Service for tracking skills and learning progress.
-class SkillTrackerService {
+class SkillTrackerService with ServicePersistence {
   final List<SkillEntry> _skills = [];
+
+  @override
+  String get storageKey => 'skill_tracker_data';
+
+  @override
+  Map<String, dynamic> toStorageJson() => {
+        'skills': _skills.map((s) => s.toJson()).toList(),
+      };
+
+  @override
+  void fromStorageJson(Map<String, dynamic> json) {
+    _skills.clear();
+    if (json['skills'] != null) {
+      _skills.addAll(
+        (json['skills'] as List)
+            .map((s) => SkillEntry.fromJson(s as Map<String, dynamic>)),
+      );
+    }
+  }
 
   List<SkillEntry> get skills => List.unmodifiable(_skills);
   List<SkillEntry> get activeSkills =>
@@ -118,6 +138,7 @@ class SkillTrackerService {
       throw ArgumentError('Skill with id ${skill.id} already exists');
     }
     _skills.add(skill);
+    persistState();
   }
 
   SkillEntry? getSkill(String id) {
@@ -132,10 +153,12 @@ class SkillTrackerService {
     final idx = _skills.indexWhere((s) => s.id == updated.id);
     if (idx < 0) throw ArgumentError('Skill ${updated.id} not found');
     _skills[idx] = updated;
+    persistState();
   }
 
   void removeSkill(String id) {
     _skills.removeWhere((s) => s.id == id);
+    persistState();
   }
 
   void archiveSkill(String id) {


### PR DESCRIPTION
## Summary

Partial fix for #42 — adds automatic persistence to 5 of the 39 services that lose data on restart.

## Approach

Created a \ServicePersistence\ mixin that provides automatic SharedPreferences-based save/restore. Applied to HabitTrackerService, ExpenseTrackerService, GoalTrackerService, GratitudeJournalService, and SkillTrackerService.

Each service now auto-saves after every mutation and can restore state on startup via \estoreState()\. The remaining ~34 services can adopt the same pattern incrementally.