### PR TITLE
fix: remove invalid static method + optimize monthly report daily summaries

### DIFF
--- a/lib/core/services/daily_timeline_service.dart
+++ b/lib/core/services/daily_timeline_service.dart
@@ -299,10 +299,4 @@ class DailyTimelineService {
     }
     return buffer.toString();
   }
-
-  static String FormattingUtils.formatTime24h(DateTime dt) {
-    final hour = dt.hour.toString().padLeft(2, '0');
-    final minute = dt.minute.toString().padLeft(2, '0');
-    return '$hour:$minute';
-  }
 }

--- a/lib/core/services/expense_tracker_service.dart
+++ b/lib/core/services/expense_tracker_service.dart
@@ -386,16 +386,42 @@ class ExpenseTrackerService {
           (byPayment[e.paymentMethod] ?? 0) + e.amount;
     }
 
-    // Daily summaries for the month
+    // Daily summaries — pre-group entries by day to avoid O(days * entries)
+    // rescanning.  Previous code called getDailySummary() per day, each of
+    // which scanned the full entry list via getEntriesForDate().
     final daysInMonth = DateTime(year, month + 1, 0).day;
+    final dayBuckets = <int, List<ExpenseEntry>>{};
+    for (final e in monthEntries) {
+      dayBuckets.putIfAbsent(e.timestamp.day, () => []).add(e);
+    }
     final dailySummaries = <DailyExpenseSummary>[];
     int daysWithData = 0;
     for (int d = 1; d <= daysInMonth; d++) {
       final date = DateTime(year, month, d);
       if (date.isAfter(DateTime.now())) break;
-      final summary = getDailySummary(date);
-      dailySummaries.add(summary);
-      if (summary.transactionCount > 0) daysWithData++;
+      final dayEntries = dayBuckets[d] ?? [];
+      double daySpent = 0;
+      double dayIncome = 0;
+      final dayCat = <ExpenseCategory, double>{};
+      final dayPay = <PaymentMethod, double>{};
+      for (final e in dayEntries) {
+        if (e.category.isIncome) {
+          dayIncome += e.amount;
+        } else {
+          daySpent += e.amount;
+        }
+        dayCat[e.category] = (dayCat[e.category] ?? 0) + e.amount;
+        dayPay[e.paymentMethod] = (dayPay[e.paymentMethod] ?? 0) + e.amount;
+      }
+      dailySummaries.add(DailyExpenseSummary(
+        date: date,
+        totalSpent: daySpent,
+        totalIncome: dayIncome,
+        transactionCount: dayEntries.length,
+        byCategory: dayCat,
+        byPaymentMethod: dayPay,
+      ));
+      if (dayEntries.isNotEmpty) daysWithData++;
     }
 
     final avgDaily =


### PR DESCRIPTION
## Bug Fix + Performance Improvement

### Bug Fix: DailyTimelineService — invalid static method (compile error)

Line 303 defined `static String FormattingUtils.formatTime24h(DateTime dt)` — **Dart does not allow dots in method names**. This would cause a compile error.

The method was redundant: `FormattingUtils` is already imported at the top of the file, and called correctly via `FormattingUtils.formatTime24h(...)` on lines 288-289. The broken static duplicate has been removed.

### Perf Improvement: ExpenseTrackerService.getMonthlyReport — O(31n) → O(n)

`getMonthlyReport()` called `getDailySummary()` for each day of the month (up to 31 times). Each `getDailySummary()` call invoked `getEntriesForDate()`, which does a full **O(n) linear scan** of all entries. For a 31-day month, this produced **O(31n)** work.

**Fix**: Pre-group the already-filtered month entries into day buckets via a single **O(n)** pass using a `Map<int, List<ExpenseEntry>>`. Daily summaries are then built from the pre-grouped map, eliminating redundant scans.

This also means `getFullReport()` and `generateInsights()` (which call `getMonthlyReport()`) benefit transitively.
