### PR TITLE
fix: debt payoff snowball bug + workout report O(8n)→O(n)

### DIFF
--- a/lib/core/services/debt_payoff_service.dart
+++ b/lib/core/services/debt_payoff_service.dart
@@ -170,10 +170,13 @@ class DebtPayoffService {
     var totalPaid = 0.0;
     var month = 0;
     const maxMonths = 600;
+    // Track freed minimums from paid-off debts so they snowball
+    // into future months (the core mechanic of debt snowball/avalanche).
+    var freedMinimums = 0.0;
 
     while (balances.values.any((b) => b > 0.01) && month < maxMonths) {
       month++;
-      var extraLeft = extraPayment;
+      var extraLeft = extraPayment + freedMinimums;
 
       for (final id in balances.keys.toList()) {
         if (balances[id]! <= 0.01) continue;
@@ -196,7 +199,11 @@ class DebtPayoffService {
 
         if (balances[id]! <= 0.01 && !payoffOrder.contains(id)) {
           payoffOrder.add(id);
-          extraLeft += mins[id]!;
+          // Freed minimum is permanently available for future months.
+          freedMinimums += mins[id]!;
+          // Also make the surplus available this month: the actual payment
+          // was min(mins[id], bal), so the unused portion is freed now.
+          extraLeft += mins[id]! - payment;
         }
       }
 
@@ -221,7 +228,7 @@ class DebtPayoffService {
 
         if (balances[id]! <= 0.01 && !payoffOrder.contains(id)) {
           payoffOrder.add(id);
-          extraLeft += mins[id]!;
+          freedMinimums += mins[id]!;
         }
       }
     }

--- a/lib/core/services/workout_tracker_service.dart
+++ b/lib/core/services/workout_tracker_service.dart
@@ -650,27 +650,40 @@ class WorkoutTrackerService {
   // ── Full Report ──
 
   WorkoutReport generateReport() {
-    final totalMinutes = _workouts
-        .where((w) => w.durationMinutes != null)
-        .fold<int>(0, (sum, w) => sum + w.durationMinutes!);
-    final durationCount =
-        _workouts.where((w) => w.durationMinutes != null).length;
-    final rpeSum = _workouts
-        .where((w) => w.rpeScore != null)
-        .fold<int>(0, (sum, w) => sum + w.rpeScore!);
-    final rpeCount = _workouts.where((w) => w.rpeScore != null).length;
+    // Single-pass aggregation: O(n) instead of O(8n) from separate
+    // fold/where/length calls over _workouts.
+    var totalVolume = 0.0;
+    var totalSets = 0;
+    var totalReps = 0;
+    var totalMinutes = 0;
+    var durationCount = 0;
+    var rpeSum = 0;
+    var rpeCount = 0;
+
+    for (final w in _workouts) {
+      totalVolume += w.totalVolume;
+      totalSets += w.totalSets;
+      totalReps += w.totalReps;
+      if (w.durationMinutes != null) {
+        totalMinutes += w.durationMinutes!;
+        durationCount++;
+      }
+      if (w.rpeScore != null) {
+        rpeSum += w.rpeScore!;
+        rpeCount++;
+      }
+    }
 
     return WorkoutReport(
       totalWorkouts: _workouts.length,
-      totalVolume: _workouts.fold(0.0, (sum, w) => sum + w.totalVolume),
-      totalSets: _workouts.fold(0, (sum, w) => sum + w.totalSets),
-      totalReps: _workouts.fold(0, (sum, w) => sum + w.totalReps),
+      totalVolume: totalVolume,
+      totalSets: totalSets,
+      totalReps: totalReps,
       totalMinutes: totalMinutes,
       avgWorkoutMinutes:
           durationCount > 0 ? totalMinutes / durationCount : 0,
       avgVolume: _workouts.isNotEmpty
-          ? _workouts.fold(0.0, (sum, w) => sum + w.totalVolume) /
-              _workouts.length
+          ? totalVolume / _workouts.length
           : 0,
       avgRpe: rpeCount > 0 ? rpeSum / rpeCount : 0,
       streak: getStreak(),


### PR DESCRIPTION
## Fix: Debt Payoff Snowball Bug + Workout Report Perf

### 1. Bug Fix: `DebtPayoffService.computePlan()` — Broken Snowball/Avalanche

**Problem:** Freed minimums from paid-off debts were not accumulated across months. Each iteration of the payoff loop reset `extraLeft = extraPayment`, discarding the minimums freed by previously paid-off debts. This is the **core mechanic** of debt snowball/avalanche — when a debt is eliminated, its minimum payment should permanently add to the pool targeting the next debt.

**Impact:** Payoff timelines were dramatically underestimated. With 3+ debts, the strategy showed minimal difference between snowball and avalanche because the freed-minimum cascade never happened.

**Fix:**
- Added `freedMinimums` accumulator that grows permanently as debts are paid off
- Each month: `extraLeft = extraPayment + freedMinimums`
- When a debt is paid off during minimum-payment phase: only the unused surplus (`mins[id] - payment`) is freed immediately for the current month; the full minimum is added to `freedMinimums` for future months

### 2. Perf: `WorkoutTrackerService.generateReport()` — O(8n) → O(n)

**Problem:** `generateReport()` made 8 separate passes through `_workouts`:
- 2× `fold` for `totalVolume` (duplicate!)
- 2× `where` + `fold` for duration stats
- 2× `where` for RPE stats
- 2× `fold` for sets and reps

**Fix:** Replaced with a single `for` loop that computes all aggregates in one pass. Also eliminated the duplicate `totalVolume` computation that was calculated once for the field and again for `avgVolume`.
