### PR TITLE
feat: add SharedPreferences persistence to 5 more tracker screens

### DIFF
--- a/lib/views/home/chore_tracker_screen.dart
+++ b/lib/views/home/chore_tracker_screen.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/chore_tracker_service.dart';
 import '../../models/chore_entry.dart';
 
@@ -13,6 +15,8 @@ class ChoreTrackerScreen extends StatefulWidget {
 
 class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _choresKey = 'chore_tracker_chores';
+  static const _completionsKey = 'chore_tracker_completions';
   final ChoreTrackerService _service = const ChoreTrackerService();
   late TabController _tabController;
   final List<Chore> _chores = [];
@@ -26,6 +30,42 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final choresJson = prefs.getString(_choresKey);
+    final compsJson = prefs.getString(_completionsKey);
+    if (choresJson != null && choresJson.isNotEmpty) {
+      try {
+        final chores = (jsonDecode(choresJson) as List)
+            .map((e) => Chore.fromJson(e as Map<String, dynamic>))
+            .toList();
+        final comps = compsJson != null && compsJson.isNotEmpty
+            ? (jsonDecode(compsJson) as List)
+                .map((e) => ChoreCompletion.fromJson(e as Map<String, dynamic>))
+                .toList()
+            : <ChoreCompletion>[];
+        if (mounted) {
+          setState(() {
+            _chores.addAll(chores);
+            _completions.addAll(comps);
+            _nextChoreId = _chores.length + 1;
+            _nextCompId = _completions.length + 1;
+          });
+          _saveData();
+        }
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_choresKey,
+        jsonEncode(_chores.map((c) => c.toJson()).toList()));
+    await prefs.setString(_completionsKey,
+        jsonEncode(_completions.map((c) => c.toJson()).toList()));
   }
 
   @override
@@ -47,6 +87,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
 
   void _addChore(Chore chore) {
     setState(() => _chores.add(chore));
+    _saveData();
   }
 
   void _toggleArchive(int index) {
@@ -54,6 +95,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
       final c = _chores[index];
       _chores[index] = c.copyWith(archived: !c.archived);
     });
+    _saveData();
   }
 
   void _logCompletion(String choreId, {int duration = 0, int rating = 3, String? note}) {
@@ -67,6 +109,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
         note: note,
       ));
     });
+    _saveData();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: const Text('✅ Chore completed!'),
@@ -178,6 +221,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
         ),
       ],
     );
+    _saveData();
   }
 
   Widget _buildChoreCard(Chore chore) {
@@ -711,6 +755,7 @@ class _AddChoreFormState extends State<_AddChoreForm> {
               selected: _room == room,
               onSelected: (_) => setState(() => _room = room),
             );
+            _saveData();
           }).toList(),
         ),
         const SizedBox(height: 16),
@@ -727,6 +772,7 @@ class _AddChoreFormState extends State<_AddChoreForm> {
               selected: _frequency == freq,
               onSelected: (_) => setState(() => _frequency = freq),
             );
+            _saveData();
           }).toList(),
         ),
         const SizedBox(height: 16),
@@ -743,6 +789,7 @@ class _AddChoreFormState extends State<_AddChoreForm> {
               selected: _effort == eff,
               onSelected: (_) => setState(() => _effort = eff),
             );
+            _saveData();
           }).toList(),
         ),
         const SizedBox(height: 16),
@@ -790,6 +837,7 @@ class _AddChoreFormState extends State<_AddChoreForm> {
               _frequency = ChoreFrequency.weekly;
               _effort = ChoreEffort.moderate;
             });
+            _saveData();
           },
         ),
 

--- a/lib/views/home/debt_payoff_screen.dart
+++ b/lib/views/home/debt_payoff_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/debt_payoff_service.dart';
 import '../../models/debt_entry.dart';
 
@@ -13,6 +14,7 @@ class DebtPayoffScreen extends StatefulWidget {
 
 class _DebtPayoffScreenState extends State<DebtPayoffScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'debt_payoff_data';
   final DebtPayoffService _service = DebtPayoffService();
   late TabController _tabController;
   double _extraPayment = 0;
@@ -21,6 +23,23 @@ class _DebtPayoffScreenState extends State<DebtPayoffScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.importFromJson(json);
+        if (mounted) setState(() {});
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
   }
 
   @override
@@ -155,9 +174,11 @@ class _DebtPayoffScreenState extends State<DebtPayoffScreen>
                   if (v == 'pay') _showPaymentDialog(debt);
                   if (v == 'paidoff') {
                     setState(() => _service.markPaidOff(debt.id));
+                    _saveData();
                   }
                   if (v == 'delete') {
                     setState(() => _service.removeDebt(debt.id));
+                    _saveData();
                   }
                 },
                 itemBuilder: (_) => [
@@ -256,6 +277,7 @@ class _DebtPayoffScreenState extends State<DebtPayoffScreen>
         _payoffOrderList('Avalanche', avalanche),
       ],
     );
+    _saveData();
   }
 
   Widget _strategyCard(String title, PayoffPlan plan, String subtitle) {
@@ -492,6 +514,7 @@ class _DebtPayoffScreenState extends State<DebtPayoffScreen>
                       category: category,
                     );
                   });
+                  _saveData();
                   Navigator.pop(ctx);
                 }
               },
@@ -537,6 +560,7 @@ class _DebtPayoffScreenState extends State<DebtPayoffScreen>
                   _service.addPayment(debt.id, amount,
                       note: noteCtl.text.isEmpty ? null : noteCtl.text);
                 });
+                _saveData();
                 Navigator.pop(ctx);
               }
             },

--- a/lib/views/home/grocery_list_screen.dart
+++ b/lib/views/home/grocery_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/grocery_list_service.dart';
 import '../../models/grocery_item.dart';
 
@@ -13,6 +14,7 @@ class GroceryListScreen extends StatefulWidget {
 
 class _GroceryListScreenState extends State<GroceryListScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'grocery_list_data';
   late final GroceryListService _service;
   late TabController _tabController;
   String? _selectedListId;
@@ -22,6 +24,23 @@ class _GroceryListScreenState extends State<GroceryListScreen>
     super.initState();
     _service = GroceryListService();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.importFromJson(json);
+        if (mounted) setState(() {});
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
   }
 
   @override
@@ -56,6 +75,8 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   final list = _service.createList(controller.text.trim());
                   _selectedListId = list.id;
                 });
+                _saveData();
+                _saveData();
                 Navigator.pop(ctx);
               }
             },
@@ -205,6 +226,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                       estimatedPrice: double.tryParse(priceController.text),
                     );
                   });
+                  _saveData();
                   Navigator.pop(ctx);
                 }
               },
@@ -242,15 +264,18 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                 switch (action) {
                   case 'clear_checked':
                     setState(() => _service.clearChecked(_selectedListId!));
+                    _saveData();
                     break;
                   case 'duplicate':
                     setState(() => _service.duplicateList(_selectedListId!));
+                    _saveData();
                     break;
                   case 'archive':
                     setState(() {
                       _service.toggleArchive(_selectedListId!);
                       _selectedListId = null;
                     });
+                    _saveData();
                     break;
                 }
               },
@@ -390,6 +415,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
             _selectedListId = list.id;
             _tabController.animateTo(1);
           });
+          _saveData();
         },
         onLongPress: () {
           showModalBottomSheet(
@@ -402,6 +428,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   title: Text(isArchived ? 'Unarchive' : 'Archive'),
                   onTap: () {
                     setState(() => _service.toggleArchive(list.id));
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -410,6 +437,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   title: const Text('Duplicate'),
                   onTap: () {
                     setState(() => _service.duplicateList(list.id));
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -422,6 +450,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                       _service.deleteList(list.id);
                       if (_selectedListId == list.id) _selectedListId = null;
                     });
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -544,12 +573,14 @@ class _GroceryListScreenState extends State<GroceryListScreen>
       ),
       onDismissed: (_) {
         setState(() => _service.removeItem(listId, item.id));
+        _saveData();
       },
       child: ListTile(
         leading: Checkbox(
           value: item.isChecked,
           onChanged: (_) {
             setState(() => _service.toggleItem(listId, item.id));
+            _saveData();
           },
         ),
         title: Text(

--- a/lib/views/home/medication_tracker_screen.dart
+++ b/lib/views/home/medication_tracker_screen.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/medication_tracker_service.dart';
 import '../../models/medication_entry.dart';
 
@@ -12,6 +14,8 @@ class MedicationTrackerScreen extends StatefulWidget {
 
 class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _medsKey = 'medication_tracker_meds';
+  static const _logsKey = 'medication_tracker_logs';
   final MedicationTrackerService _service = const MedicationTrackerService();
   late TabController _tabController;
   final List<Medication> _medications = [];
@@ -24,6 +28,42 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final medsJson = prefs.getString(_medsKey);
+    final logsJson = prefs.getString(_logsKey);
+    if (medsJson != null && medsJson.isNotEmpty) {
+      try {
+        final meds = (jsonDecode(medsJson) as List)
+            .map((e) => Medication.fromJson(e as Map<String, dynamic>))
+            .toList();
+        final logs = logsJson != null && logsJson.isNotEmpty
+            ? (jsonDecode(logsJson) as List)
+                .map((e) => DoseLog.fromJson(e as Map<String, dynamic>))
+                .toList()
+            : <DoseLog>[];
+        if (mounted) {
+          setState(() {
+            _medications.addAll(meds);
+            _logs.addAll(logs);
+            _nextMedId = _medications.length + 1;
+            _nextLogId = _logs.length + 1;
+          });
+          _saveData();
+        }
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_medsKey,
+        jsonEncode(_medications.map((m) => m.toJson()).toList()));
+    await prefs.setString(_logsKey,
+        jsonEncode(_logs.map((l) => l.toJson()).toList()));
   }
 
   @override
@@ -49,6 +89,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
         sideEffects: sideEffects,
       ));
     });
+    _saveData();
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text(skip
           ? '⏭️ ${med.name} skipped (${time.label})'
@@ -175,6 +216,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                     color: color,
                   ));
                 });
+                _saveData();
                 Navigator.pop(ctx);
               },
               child: const Text('Add'),
@@ -394,11 +436,13 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                 final idx = _medications.indexOf(med);
                 _medications[idx] = med.copyWith(active: !med.active);
               });
+              _saveData();
             } else if (action == 'delete') {
               setState(() {
                 _medications.remove(med);
                 _logs.removeWhere((l) => l.medicationId == med.id);
               });
+              _saveData();
             }
           },
           itemBuilder: (_) => [
@@ -559,6 +603,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                   lastDate: DateTime.now(),
                 );
                 if (picked != null) setState(() => _selectedDate = picked);
+                _saveData();
               },
               child: Text(
                 _sameDay(_selectedDate, DateTime.now())
@@ -604,6 +649,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                     onDismissed: (_) {
                       final idx = _logs.indexOf(log);
                       setState(() => _logs.remove(log));
+                      _saveData();
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: const Text('Log entry removed'),
                         action: SnackBarAction(
@@ -612,6 +658,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                               setState(() => _logs.insert(idx, log)),
                         ),
                       ));
+                      _saveData();
                     },
                     child: Card(
                       child: ListTile(

--- a/lib/views/home/savings_goal_screen.dart
+++ b/lib/views/home/savings_goal_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/savings_goal_service.dart';
 import '../../models/savings_goal.dart';
 
@@ -13,6 +14,7 @@ class SavingsGoalScreen extends StatefulWidget {
 
 class _SavingsGoalScreenState extends State<SavingsGoalScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'savings_goal_data';
   final SavingsGoalService _service = SavingsGoalService();
   late TabController _tabController;
   SavingsGoalCategory? _filterCategory;
@@ -22,6 +24,23 @@ class _SavingsGoalScreenState extends State<SavingsGoalScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.importJson(json);
+        if (mounted) setState(() {});
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportJson());
   }
 
   @override
@@ -67,6 +86,7 @@ class _SavingsGoalScreenState extends State<SavingsGoalScreen>
         ],
       ),
     );
+    _saveData();
   }
 }
 
@@ -567,6 +587,7 @@ class _AddTabState extends State<_AddTab> {
             }).toList(),
             onChanged: (val) {
               if (val != null) setState(() => _category = val);
+              _saveData();
             },
           ),
           const SizedBox(height: 16),
@@ -587,6 +608,7 @@ class _AddTabState extends State<_AddTab> {
             }).toList(),
             onChanged: (val) {
               if (val != null) setState(() => _priority = val);
+              _saveData();
             },
           ),
           const SizedBox(height: 16),
@@ -615,6 +637,7 @@ class _AddTabState extends State<_AddTab> {
                 lastDate: DateTime.now().add(const Duration(days: 3650)),
               );
               if (date != null) setState(() => _deadline = date);
+              _saveData();
             },
           ),
           const SizedBox(height: 24),
@@ -650,6 +673,7 @@ class _AddTabState extends State<_AddTab> {
                 _priority = SavingsGoalPriority.medium;
                 _deadline = null;
               });
+              _saveData();
 
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(content: Text('Goal "$name" created!')),


### PR DESCRIPTION
Partial fix for #42

Adds data persistence via SharedPreferences to 5 screens that previously lost all data on app restart:

| Screen | Data Persisted |
|--------|---------------|
| Grocery List | Lists, items, check-off state |
| Medication Tracker | Medications, dose logs |
| Chore Tracker | Chores, completions |
| Savings Goals | Goals, contributions |
| Debt Payoff | Debt entries, payments |

Each screen loads saved data in \initState\ and saves after every \setState\ mutation using the models' existing \	oJson()\/\romJson()\ serialization.

**Note:** This is an incremental fix — 5 of 39 unpersisted screens. The remaining screens can follow the same pattern in subsequent PRs. Some screens (sleep tracker, habit tracker, expense tracker, etc.) already had persistence.