### PR TITLE
feat: add SharedPreferences persistence to 5 more screens

### DIFF
--- a/lib/models/bucket_item.dart
+++ b/lib/models/bucket_item.dart
@@ -82,6 +82,55 @@ class BucketItem {
     this.inspiration,
   });
 
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'title': title,
+    'description': description,
+    'category': category.name,
+    'priority': priority.name,
+    'effort': effort.name,
+    'estimatedCost': estimatedCost,
+    'location': location,
+    'tags': tags,
+    'createdAt': createdAt.toIso8601String(),
+    'targetDate': targetDate?.toIso8601String(),
+    'completedAt': completedAt?.toIso8601String(),
+    'completionNotes': completionNotes,
+    'rating': rating,
+    'inspiration': inspiration,
+  };
+
+  factory BucketItem.fromJson(Map<String, dynamic> json) => BucketItem(
+    id: json['id'] as String,
+    title: json['title'] as String,
+    description: json['description'] as String?,
+    category: BucketCategory.values.firstWhere(
+        (e) => e.name == json['category'],
+        orElse: () => BucketCategory.personal),
+    priority: BucketPriority.values.firstWhere(
+        (e) => e.name == json['priority'],
+        orElse: () => BucketPriority.someday),
+    effort: BucketEffort.values.firstWhere(
+        (e) => e.name == json['effort'],
+        orElse: () => BucketEffort.moderate),
+    estimatedCost: (json['estimatedCost'] as num?)?.toDouble(),
+    location: json['location'] as String?,
+    tags: (json['tags'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        const [],
+    createdAt: DateTime.parse(json['createdAt'] as String),
+    targetDate: json['targetDate'] != null
+        ? DateTime.parse(json['targetDate'] as String)
+        : null,
+    completedAt: json['completedAt'] != null
+        ? DateTime.parse(json['completedAt'] as String)
+        : null,
+    completionNotes: json['completionNotes'] as String?,
+    rating: json['rating'] as int? ?? 0,
+    inspiration: json['inspiration'] as String?,
+  );
+
   bool get isCompleted => completedAt != null;
 
   bool get isOverdue =>

--- a/lib/models/travel_entry.dart
+++ b/lib/models/travel_entry.dart
@@ -97,6 +97,46 @@ class TravelEntry {
   bool get isUpcoming =>
       startDate.isAfter(DateTime.now()) && !isCompleted;
 
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'destination': destination,
+    'country': country,
+    'startDate': startDate.toIso8601String(),
+    'endDate': endDate.toIso8601String(),
+    'type': type.name,
+    'transport': transport.name,
+    'rating': rating?.name,
+    'totalCost': totalCost,
+    'currency': currency,
+    'highlights': highlights,
+    'notes': notes,
+    'isCompleted': isCompleted,
+  };
+
+  factory TravelEntry.fromJson(Map<String, dynamic> json) => TravelEntry(
+    id: json['id'] as String,
+    destination: json['destination'] as String,
+    country: json['country'] as String?,
+    startDate: DateTime.parse(json['startDate'] as String),
+    endDate: DateTime.parse(json['endDate'] as String),
+    type: TripType.values.firstWhere((e) => e.name == json['type'],
+        orElse: () => TripType.leisure),
+    transport: TripTransport.values.firstWhere((e) => e.name == json['transport'],
+        orElse: () => TripTransport.car),
+    rating: json['rating'] != null
+        ? TripRating.values.firstWhere((e) => e.name == json['rating'],
+            orElse: () => TripRating.good)
+        : null,
+    totalCost: (json['totalCost'] as num?)?.toDouble(),
+    currency: json['currency'] as String?,
+    highlights: (json['highlights'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        const [],
+    notes: json['notes'] as String?,
+    isCompleted: json['isCompleted'] as bool? ?? true,
+  );
+
   TravelEntry copyWith({
     String? destination,
     String? country,

--- a/lib/models/wishlist_item.dart
+++ b/lib/models/wishlist_item.dart
@@ -93,6 +93,66 @@ class WishlistItem {
     this.isFavorite = false,
   });
 
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'name': name,
+    'description': description,
+    'category': category.name,
+    'urgency': urgency.name,
+    'estimatedPrice': estimatedPrice,
+    'url': url,
+    'imageUrl': imageUrl,
+    'priceHistory': priceHistory.map((p) => {
+      'date': p.date.toIso8601String(),
+      'price': p.price,
+      'note': p.note,
+    }).toList(),
+    'createdAt': createdAt.toIso8601String(),
+    'purchasedAt': purchasedAt?.toIso8601String(),
+    'purchasedPrice': purchasedPrice,
+    'isPurchased': isPurchased,
+    'rating': rating,
+    'tags': tags,
+    'notes': notes,
+    'isFavorite': isFavorite,
+  };
+
+  factory WishlistItem.fromJson(Map<String, dynamic> json) => WishlistItem(
+    id: json['id'] as String,
+    name: json['name'] as String,
+    description: json['description'] as String?,
+    category: WishlistCategory.values.firstWhere(
+        (e) => e.name == json['category'],
+        orElse: () => WishlistCategory.other),
+    urgency: WishlistUrgency.values.firstWhere(
+        (e) => e.name == json['urgency'],
+        orElse: () => WishlistUrgency.considering),
+    estimatedPrice: (json['estimatedPrice'] as num?)?.toDouble(),
+    url: json['url'] as String?,
+    imageUrl: json['imageUrl'] as String?,
+    priceHistory: (json['priceHistory'] as List<dynamic>?)
+            ?.map((p) => PricePoint(
+                  date: DateTime.parse(p['date'] as String),
+                  price: (p['price'] as num).toDouble(),
+                  note: p['note'] as String?,
+                ))
+            .toList() ??
+        const [],
+    createdAt: DateTime.parse(json['createdAt'] as String),
+    purchasedAt: json['purchasedAt'] != null
+        ? DateTime.parse(json['purchasedAt'] as String)
+        : null,
+    purchasedPrice: (json['purchasedPrice'] as num?)?.toDouble(),
+    isPurchased: json['isPurchased'] as bool? ?? false,
+    rating: json['rating'] as int? ?? 0,
+    tags: (json['tags'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+        const [],
+    notes: json['notes'] as String?,
+    isFavorite: json['isFavorite'] as bool? ?? false,
+  );
+
   /// Days since this item was added.
   int get daysOnList =>
       DateTime.now().difference(createdAt).inDays;

--- a/lib/views/home/bucket_list_screen.dart
+++ b/lib/views/home/bucket_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/bucket_item.dart';
 import '../../core/services/bucket_list_service.dart';
+import '../../core/services/screen_persistence.dart';
 
 /// Bucket List screen — 4-tab UI for tracking life dreams and experiences.
 class BucketListScreen extends StatefulWidget {
@@ -13,6 +14,11 @@ class _BucketListScreenState extends State<BucketListScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   final _service = const BucketListService();
+  final _persistence = ScreenPersistence<BucketItem>(
+    storageKey: 'bucket_list_items',
+    toJson: (e) => e.toJson(),
+    fromJson: BucketItem.fromJson,
+  );
   final List<BucketItem> _items = [];
   String _searchQuery = '';
   BucketCategory? _filterCategory;
@@ -22,6 +28,18 @@ class _BucketListScreenState extends State<BucketListScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadItems();
+  }
+
+  Future<void> _loadItems() async {
+    final saved = await _persistence.load();
+    if (saved.isNotEmpty) {
+      setState(() => _items.addAll(saved));
+    }
+  }
+
+  void _saveItems() {
+    _persistence.save(_items);
   }
 
   @override
@@ -30,10 +48,15 @@ class _BucketListScreenState extends State<BucketListScreen>
     super.dispose();
   }
 
-  void _addItem(BucketItem item) => setState(() => _items.add(item));
+  void _addItem(BucketItem item) {
+    setState(() => _items.add(item));
+    _saveItems();
+  }
 
-  void _deleteItem(String id) =>
-      setState(() => _items.removeWhere((i) => i.id == id));
+  void _deleteItem(String id) {
+    setState(() => _items.removeWhere((i) => i.id == id));
+    _saveItems();
+  }
 
   void _completeItem(String id, {String? notes, int? rating}) {
     setState(() {
@@ -42,6 +65,7 @@ class _BucketListScreenState extends State<BucketListScreen>
         _items[idx] = _items[idx].markComplete(notes: notes, rating: rating);
       }
     });
+    _saveItems();
   }
 
   @override

--- a/lib/views/home/medication_tracker_screen.dart
+++ b/lib/views/home/medication_tracker_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/medication_tracker_service.dart';
+import '../../core/services/screen_persistence.dart';
 import '../../models/medication_entry.dart';
 
 /// Medication Tracker screen — manage medications, track doses, view adherence.
@@ -13,6 +14,16 @@ class MedicationTrackerScreen extends StatefulWidget {
 class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
     with SingleTickerProviderStateMixin {
   final MedicationTrackerService _service = const MedicationTrackerService();
+  final _medPersistence = ScreenPersistence<Medication>(
+    storageKey: 'medication_tracker_meds',
+    toJson: (e) => e.toJson(),
+    fromJson: Medication.fromJson,
+  );
+  final _logPersistence = ScreenPersistence<DoseLog>(
+    storageKey: 'medication_tracker_logs',
+    toJson: (e) => e.toJson(),
+    fromJson: DoseLog.fromJson,
+  );
   late TabController _tabController;
   final List<Medication> _medications = [];
   final List<DoseLog> _logs = [];
@@ -24,6 +35,25 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final savedMeds = await _medPersistence.load();
+    final savedLogs = await _logPersistence.load();
+    if (savedMeds.isNotEmpty || savedLogs.isNotEmpty) {
+      setState(() {
+        _medications.addAll(savedMeds);
+        _logs.addAll(savedLogs);
+        _nextMedId = _medications.length + 1;
+        _nextLogId = _logs.length + 1;
+      });
+    }
+  }
+
+  void _saveAll() {
+    _medPersistence.save(_medications);
+    _logPersistence.save(_logs);
   }
 
   @override
@@ -49,6 +79,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
         sideEffects: sideEffects,
       ));
     });
+    _saveAll();
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text(skip
           ? '⏭️ ${med.name} skipped (${time.label})'
@@ -175,6 +206,7 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                     color: color,
                   ));
                 });
+                _saveAll();
                 Navigator.pop(ctx);
               },
               child: const Text('Add'),
@@ -394,11 +426,13 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                 final idx = _medications.indexOf(med);
                 _medications[idx] = med.copyWith(active: !med.active);
               });
+              _saveAll();
             } else if (action == 'delete') {
               setState(() {
                 _medications.remove(med);
                 _logs.removeWhere((l) => l.medicationId == med.id);
               });
+              _saveAll();
             }
           },
           itemBuilder: (_) => [
@@ -604,12 +638,15 @@ class _MedicationTrackerScreenState extends State<MedicationTrackerScreen>
                     onDismissed: (_) {
                       final idx = _logs.indexOf(log);
                       setState(() => _logs.remove(log));
+                      _saveAll();
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: const Text('Log entry removed'),
                         action: SnackBarAction(
                           label: 'Undo',
-                          onPressed: () =>
-                              setState(() => _logs.insert(idx, log)),
+                          onPressed: () {
+                              setState(() => _logs.insert(idx, log));
+                              _saveAll();
+                          },
                         ),
                       ));
                     },

--- a/lib/views/home/pet_care_tracker_screen.dart
+++ b/lib/views/home/pet_care_tracker_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/pet_care_service.dart';
+import '../../core/services/screen_persistence.dart';
 import '../../models/pet_entry.dart';
 
 /// Pet Care Tracker — manage pets, log care activities, track health records,
@@ -14,6 +15,21 @@ class PetCareTrackerScreen extends StatefulWidget {
 class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
     with SingleTickerProviderStateMixin {
   final PetCareService _service = const PetCareService();
+  final _petPersistence = ScreenPersistence<Pet>(
+    storageKey: 'pet_care_pets',
+    toJson: (e) => e.toJson(),
+    fromJson: Pet.fromJson,
+  );
+  final _carePersistence = ScreenPersistence<CareEntry>(
+    storageKey: 'pet_care_entries',
+    toJson: (e) => e.toJson(),
+    fromJson: CareEntry.fromJson,
+  );
+  final _healthPersistence = ScreenPersistence<HealthRecord>(
+    storageKey: 'pet_care_health',
+    toJson: (e) => e.toJson(),
+    fromJson: HealthRecord.fromJson,
+  );
   late TabController _tabController;
 
   final List<Pet> _pets = [];
@@ -28,6 +44,30 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final savedPets = await _petPersistence.load();
+    final savedCare = await _carePersistence.load();
+    final savedHealth = await _healthPersistence.load();
+    if (savedPets.isNotEmpty || savedCare.isNotEmpty || savedHealth.isNotEmpty) {
+      setState(() {
+        _pets.addAll(savedPets);
+        _careEntries.addAll(savedCare);
+        _healthRecords.addAll(savedHealth);
+        _nextPetId = _pets.length + 1;
+        _nextCareId = _careEntries.length + 1;
+        _nextHealthId = _healthRecords.length + 1;
+        if (_pets.isNotEmpty) _selectedPetId = _pets.first.id;
+      });
+    }
+  }
+
+  void _saveAll() {
+    _petPersistence.save(_pets);
+    _carePersistence.save(_careEntries);
+    _healthPersistence.save(_healthRecords);
   }
 
   @override
@@ -146,6 +186,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
                   _pets.add(pet);
                   _selectedPetId ??= pet.id;
                 });
+                _saveAll();
                 Navigator.pop(ctx);
               },
               child: const Text('Add'),
@@ -165,6 +206,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
         _selectedPetId = _pets.isNotEmpty ? _pets.first.id : null;
       }
     });
+    _saveAll();
   }
 
   // ─── Care Logging ───────────────────────────────────────────
@@ -254,6 +296,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
                     cost: double.tryParse(costCtrl.text),
                   ));
                 });
+                _saveAll();
                 Navigator.pop(ctx);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
@@ -276,6 +319,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
     final globalIndex = _careEntries.indexOf(entry);
     if (globalIndex < 0) return;
     setState(() => _careEntries.removeAt(globalIndex));
+    _saveAll();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text('Removed ${entry.category.label} entry'),
@@ -373,6 +417,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
                     nextDue: nextDue,
                   ));
                 });
+                _saveAll();
                 Navigator.pop(ctx);
               },
               child: const Text('Save'),
@@ -610,6 +655,7 @@ class _PetCareTrackerScreenState extends State<PetCareTrackerScreen>
             category: category,
           ));
         });
+        _saveAll();
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('${category.emoji} ${category.label} logged!'),

--- a/lib/views/home/travel_log_screen.dart
+++ b/lib/views/home/travel_log_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/travel_entry.dart';
 import '../../core/services/travel_log_service.dart';
+import '../../core/services/screen_persistence.dart';
 
 /// Travel Log screen — 4-tab UI for logging and reviewing trips.
 class TravelLogScreen extends StatefulWidget {
@@ -13,6 +14,11 @@ class _TravelLogScreenState extends State<TravelLogScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   final _service = const TravelLogService();
+  final _persistence = ScreenPersistence<TravelEntry>(
+    storageKey: 'travel_log_entries',
+    toJson: (e) => e.toJson(),
+    fromJson: TravelEntry.fromJson,
+  );
   final List<TravelEntry> _entries = [];
   int? _filterYear;
 
@@ -20,6 +26,18 @@ class _TravelLogScreenState extends State<TravelLogScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadEntries();
+  }
+
+  Future<void> _loadEntries() async {
+    final saved = await _persistence.load();
+    if (saved.isNotEmpty) {
+      setState(() => _entries.addAll(saved));
+    }
+  }
+
+  void _saveEntries() {
+    _persistence.save(_entries);
   }
 
   @override
@@ -30,10 +48,12 @@ class _TravelLogScreenState extends State<TravelLogScreen>
 
   void _addEntry(TravelEntry entry) {
     setState(() => _entries.add(entry));
+    _saveEntries();
   }
 
   void _deleteEntry(String id) {
     setState(() => _entries.removeWhere((e) => e.id == id));
+    _saveEntries();
   }
 
   @override

--- a/lib/views/home/wishlist_screen.dart
+++ b/lib/views/home/wishlist_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../models/wishlist_item.dart';
 import '../../core/services/wishlist_service.dart';
+import '../../core/services/screen_persistence.dart';
 
 /// Wishlist Screen — 4-tab UI for tracking things you want to buy.
 ///
@@ -20,6 +21,11 @@ class _WishlistScreenState extends State<WishlistScreen>
     with SingleTickerProviderStateMixin {
   late TabController _tabController;
   final _service = const WishlistService();
+  final _persistence = ScreenPersistence<WishlistItem>(
+    storageKey: 'wishlist_items',
+    toJson: (e) => e.toJson(),
+    fromJson: WishlistItem.fromJson,
+  );
   final List<WishlistItem> _items = [];
   String _searchQuery = '';
   WishlistCategory? _filterCategory;
@@ -42,6 +48,18 @@ class _WishlistScreenState extends State<WishlistScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadItems();
+  }
+
+  Future<void> _loadItems() async {
+    final saved = await _persistence.load();
+    if (saved.isNotEmpty) {
+      setState(() => _items.addAll(saved));
+    }
+  }
+
+  void _saveItems() {
+    _persistence.save(_items);
   }
 
   @override
@@ -88,20 +106,24 @@ class _WishlistScreenState extends State<WishlistScreen>
       _selectedCategory = WishlistCategory.other;
       _selectedUrgency = WishlistUrgency.considering;
     });
+    _saveItems();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(content: Text('Added "${item.name}" to wishlist')),
     );
     _tabController.animateTo(1);
   }
 
-  void _deleteItem(String id) =>
-      setState(() => _items.removeWhere((i) => i.id == id));
+  void _deleteItem(String id) {
+    setState(() => _items.removeWhere((i) => i.id == id));
+    _saveItems();
+  }
 
   void _toggleFavorite(String id) {
     setState(() {
       final idx = _items.indexWhere((i) => i.id == id);
       if (idx >= 0) _items[idx] = _items[idx].toggleFavorite();
     });
+    _saveItems();
   }
 
   void _markPurchased(String id) {
@@ -817,6 +839,7 @@ class _WishlistScreenState extends State<WishlistScreen>
                     );
                   }
                 });
+                _saveItems();
                 Navigator.pop(ctx);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(
@@ -884,6 +907,7 @@ class _WishlistScreenState extends State<WishlistScreen>
                             : noteCtl.text.trim());
                   }
                 });
+                _saveItems();
                 Navigator.pop(ctx);
               }
             },


### PR DESCRIPTION
Partial fix for #42. Adds persistence to 5 more tracker screens so data survives app restarts.

### Models — added toJson/fromJson:
- TravelEntry, WishlistItem + PricePoint, BucketItem

### Screens — added ScreenPersistence load/save:
- MedicationTrackerScreen (meds + dose logs)
- PetCareTrackerScreen (pets + care entries + health records)
- TravelLogScreen
- WishlistScreen (with price history)
- BucketListScreen

Uses existing ScreenPersistence<T> helper.