### PR TITLE
feat: Add persistence to 4 tracker screens (chore, commute, time, grocery)

### DIFF
--- a/lib/models/commute_entry.dart
+++ b/lib/models/commute_entry.dart
@@ -63,6 +63,32 @@ class CommuteEntry {
   /// Estimated CO₂ emissions in kg.
   double get co2Kg => (distanceKm ?? 0) * mode.co2PerKm;
 
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'date': date.toIso8601String(),
+    'mode': mode.name,
+    'durationMinutes': durationMinutes,
+    'distanceKm': distanceKm,
+    'cost': cost,
+    'comfort': comfort?.name,
+    'notes': notes,
+    'isReturn': isReturn,
+  };
+
+  factory CommuteEntry.fromJson(Map<String, dynamic> json) => CommuteEntry(
+    id: json['id'] as String,
+    date: DateTime.parse(json['date'] as String),
+    mode: CommuteMode.values.firstWhere((m) => m.name == json['mode']),
+    durationMinutes: json['durationMinutes'] as int,
+    distanceKm: (json['distanceKm'] as num?)?.toDouble(),
+    cost: (json['cost'] as num?)?.toDouble(),
+    comfort: json['comfort'] != null
+        ? CommuteComfort.values.firstWhere((c) => c.name == json['comfort'])
+        : null,
+    notes: json['notes'] as String?,
+    isReturn: json['isReturn'] as bool? ?? false,
+  );
+
   CommuteEntry copyWith({
     DateTime? date,
     CommuteMode? mode,

--- a/lib/models/time_entry.dart
+++ b/lib/models/time_entry.dart
@@ -45,6 +45,26 @@ class TimeEntry {
 
   bool get isRunning => endTime == null;
 
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'activity': activity,
+    'category': category.name,
+    'startTime': startTime.toIso8601String(),
+    'endTime': endTime?.toIso8601String(),
+    'notes': notes,
+    'tags': tags,
+  };
+
+  factory TimeEntry.fromJson(Map<String, dynamic> json) => TimeEntry(
+    id: json['id'] as String,
+    activity: json['activity'] as String,
+    category: TimeCategory.values.firstWhere((c) => c.name == json['category']),
+    startTime: DateTime.parse(json['startTime'] as String),
+    endTime: json['endTime'] != null ? DateTime.parse(json['endTime'] as String) : null,
+    notes: json['notes'] as String?,
+    tags: (json['tags'] as List<dynamic>?)?.cast<String>() ?? const [],
+  );
+
   TimeEntry copyWith({
     String? activity,
     TimeCategory? category,

--- a/lib/views/home/chore_tracker_screen.dart
+++ b/lib/views/home/chore_tracker_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/chore_tracker_service.dart';
+import '../../core/services/screen_persistence.dart';
 import '../../models/chore_entry.dart';
 
 /// Chore Tracker screen — manage household chores, log completions,
@@ -14,6 +15,16 @@ class ChoreTrackerScreen extends StatefulWidget {
 class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
     with SingleTickerProviderStateMixin {
   final ChoreTrackerService _service = const ChoreTrackerService();
+  final _choresPersistence = ScreenPersistence<Chore>(
+    storageKey: 'chore_tracker_chores',
+    toJson: (e) => e.toJson(),
+    fromJson: Chore.fromJson,
+  );
+  final _completionsPersistence = ScreenPersistence<ChoreCompletion>(
+    storageKey: 'chore_tracker_completions',
+    toJson: (e) => e.toJson(),
+    fromJson: ChoreCompletion.fromJson,
+  );
   late TabController _tabController;
   final List<Chore> _chores = [];
   final List<ChoreCompletion> _completions = [];
@@ -26,6 +37,29 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final savedChores = await _choresPersistence.load();
+    final savedCompletions = await _completionsPersistence.load();
+    if (savedChores.isNotEmpty || savedCompletions.isNotEmpty) {
+      setState(() {
+        _chores.addAll(savedChores);
+        _completions.addAll(savedCompletions);
+        if (_chores.isNotEmpty) {
+          _nextChoreId = _chores.length + 1;
+        }
+        if (_completions.isNotEmpty) {
+          _nextCompId = _completions.length + 1;
+        }
+      });
+    }
+  }
+
+  Future<void> _saveData() async {
+    await _choresPersistence.save(_chores);
+    await _completionsPersistence.save(_completions);
   }
 
   @override
@@ -47,6 +81,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
 
   void _addChore(Chore chore) {
     setState(() => _chores.add(chore));
+    _saveData();
   }
 
   void _toggleArchive(int index) {
@@ -54,6 +89,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
       final c = _chores[index];
       _chores[index] = c.copyWith(archived: !c.archived);
     });
+    _saveData();
   }
 
   void _logCompletion(String choreId, {int duration = 0, int rating = 3, String? note}) {
@@ -67,6 +103,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
         note: note,
       ));
     });
+    _saveData();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: const Text('✅ Chore completed!'),

--- a/lib/views/home/commute_tracker_screen.dart
+++ b/lib/views/home/commute_tracker_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/commute_tracker_service.dart';
+import '../../core/services/screen_persistence.dart';
 import '../../models/commute_entry.dart';
 
 /// Commute Tracker screen — log daily commutes, view history,
@@ -14,6 +15,11 @@ class CommuteTrackerScreen extends StatefulWidget {
 class _CommuteTrackerScreenState extends State<CommuteTrackerScreen>
     with SingleTickerProviderStateMixin {
   final CommuteTrackerService _service = const CommuteTrackerService();
+  final _persistence = ScreenPersistence<CommuteEntry>(
+    storageKey: 'commute_tracker_entries',
+    toJson: (e) => e.toJson(),
+    fromJson: CommuteEntry.fromJson,
+  );
   late TabController _tabController;
   final List<CommuteEntry> _entries = [];
   int _nextId = 1;
@@ -23,6 +29,17 @@ class _CommuteTrackerScreenState extends State<CommuteTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadEntries();
+  }
+
+  Future<void> _loadEntries() async {
+    final saved = await _persistence.load();
+    if (saved.isNotEmpty) {
+      setState(() {
+        _entries.addAll(saved);
+        _nextId = _entries.length + 1;
+      });
+    }
   }
 
   @override
@@ -33,10 +50,12 @@ class _CommuteTrackerScreenState extends State<CommuteTrackerScreen>
 
   void _addEntry(CommuteEntry entry) {
     setState(() => _entries.add(entry));
+    _persistence.save(_entries);
   }
 
   void _deleteEntry(String id) {
     setState(() => _entries.removeWhere((e) => e.id == id));
+    _persistence.save(_entries);
   }
 
   void _showLogDialog({bool isReturn = false}) {

--- a/lib/views/home/grocery_list_screen.dart
+++ b/lib/views/home/grocery_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/grocery_list_service.dart';
 import '../../models/grocery_item.dart';
 
@@ -16,12 +17,31 @@ class _GroceryListScreenState extends State<GroceryListScreen>
   late final GroceryListService _service;
   late TabController _tabController;
   String? _selectedListId;
+  static const _storageKey = 'grocery_list_data';
 
   @override
   void initState() {
     super.initState();
     _service = GroceryListService();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final data = prefs.getString(_storageKey);
+      if (data != null && data.isNotEmpty) {
+        setState(() => _service.importFromJson(data));
+      }
+    } catch (_) {}
+  }
+
+  Future<void> _saveData() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(_storageKey, _service.exportToJson());
+    } catch (_) {}
   }
 
   @override
@@ -56,6 +76,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   final list = _service.createList(controller.text.trim());
                   _selectedListId = list.id;
                 });
+                _saveData();
                 Navigator.pop(ctx);
               }
             },
@@ -205,6 +226,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                       estimatedPrice: double.tryParse(priceController.text),
                     );
                   });
+                  _saveData();
                   Navigator.pop(ctx);
                 }
               },
@@ -242,15 +264,18 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                 switch (action) {
                   case 'clear_checked':
                     setState(() => _service.clearChecked(_selectedListId!));
+                    _saveData();
                     break;
                   case 'duplicate':
                     setState(() => _service.duplicateList(_selectedListId!));
+                    _saveData();
                     break;
                   case 'archive':
                     setState(() {
                       _service.toggleArchive(_selectedListId!);
                       _selectedListId = null;
                     });
+                    _saveData();
                     break;
                 }
               },
@@ -402,6 +427,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   title: Text(isArchived ? 'Unarchive' : 'Archive'),
                   onTap: () {
                     setState(() => _service.toggleArchive(list.id));
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -410,6 +436,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                   title: const Text('Duplicate'),
                   onTap: () {
                     setState(() => _service.duplicateList(list.id));
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -422,6 +449,7 @@ class _GroceryListScreenState extends State<GroceryListScreen>
                       _service.deleteList(list.id);
                       if (_selectedListId == list.id) _selectedListId = null;
                     });
+                    _saveData();
                     Navigator.pop(ctx);
                   },
                 ),
@@ -544,12 +572,14 @@ class _GroceryListScreenState extends State<GroceryListScreen>
       ),
       onDismissed: (_) {
         setState(() => _service.removeItem(listId, item.id));
+      _saveData();
       },
       child: ListTile(
         leading: Checkbox(
           value: item.isChecked,
           onChanged: (_) {
             setState(() => _service.toggleItem(listId, item.id));
+      _saveData();
           },
         ),
         title: Text(

--- a/lib/views/home/time_tracker_screen.dart
+++ b/lib/views/home/time_tracker_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'dart:async';
+import '../../core/services/screen_persistence.dart';
 import '../../core/services/time_tracker_service.dart';
 import '../../models/time_entry.dart';
 
@@ -15,6 +16,11 @@ class TimeTrackerScreen extends StatefulWidget {
 class _TimeTrackerScreenState extends State<TimeTrackerScreen>
     with SingleTickerProviderStateMixin {
   final TimeTrackerService _service = const TimeTrackerService();
+  final _persistence = ScreenPersistence<TimeEntry>(
+    storageKey: 'time_tracker_entries',
+    toJson: (e) => e.toJson(),
+    fromJson: TimeEntry.fromJson,
+  );
   late TabController _tabController;
   final List<TimeEntry> _entries = [];
   int _nextId = 1;
@@ -28,6 +34,17 @@ class _TimeTrackerScreenState extends State<TimeTrackerScreen>
     _ticker = Timer.periodic(const Duration(seconds: 1), (_) {
       if (_entries.any((e) => e.isRunning)) setState(() {});
     });
+    _loadEntries();
+  }
+
+  Future<void> _loadEntries() async {
+    final saved = await _persistence.load();
+    if (saved.isNotEmpty) {
+      setState(() {
+        _entries.addAll(saved);
+        _nextId = _entries.length + 1;
+      });
+    }
   }
 
   @override
@@ -56,6 +73,7 @@ class _TimeTrackerScreenState extends State<TimeTrackerScreen>
         notes: notes,
       ));
     });
+    _persistence.save(_entries);
   }
 
   void _stopActiveTimer() {
@@ -67,11 +85,13 @@ class _TimeTrackerScreenState extends State<TimeTrackerScreen>
           _entries[idx] = active.copyWith(endTime: DateTime.now());
         }
       });
+      _persistence.save(_entries);
     }
   }
 
   void _deleteEntry(String id) {
     setState(() => _entries.removeWhere((e) => e.id == id));
+    _persistence.save(_entries);
   }
 
   void _showNewEntryDialog() {
@@ -134,6 +154,7 @@ class _TimeTrackerScreenState extends State<TimeTrackerScreen>
               if (a.isEmpty || m <= 0) return;
               final end = DateTime.now();
               setState(() => _entries.add(TimeEntry(id: 't${_nextId++}', activity: a, category: cat, startTime: end.subtract(Duration(minutes: m)), endTime: end)));
+              _persistence.save(_entries);
               Navigator.pop(ctx);
             }, child: const Text('Log')),
           ],


### PR DESCRIPTION
## Summary

Adds SharedPreferences persistence to 4 more screens that previously lost all data on app restart, partially addressing #42.

### Screens updated:
- **Chore Tracker** — chores + completions persisted
- **Commute Tracker** — commute entries persisted
- **Time Tracker** — time entries persisted
- **Grocery List** — full list state persisted via service export/import

### Model serialization added:
- \CommuteEntry.toJson()\ / \CommuteEntry.fromJson()\
- \TimeEntry.toJson()\ / \TimeEntry.fromJson()\

### Pattern
Uses the existing \ScreenPersistence<T>\ helper (same pattern as water_tracker, contact_tracker, etc.). Data is saved after every mutation and loaded on screen init.

Partially addresses #42 — 21 screens still need persistence.