### PR TITLE
feat: unified DataBackupService for backup/restore across all services

### DIFF
--- a/lib/core/services/data_backup_service.dart
+++ b/lib/core/services/data_backup_service.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+
+/// Result of a backup import operation.
+class BackupResult {
+  /// Services that were successfully restored.
+  final List<String> restored;
+
+  /// Services that were skipped (not present in backup).
+  final List<String> skipped;
+
+  /// Services that failed to restore, with error messages.
+  final Map<String, String> errors;
+
+  const BackupResult({
+    required this.restored,
+    required this.skipped,
+    required this.errors,
+  });
+
+  bool get hasErrors => errors.isNotEmpty;
+
+  @override
+  String toString() {
+    final lines = <String>[];
+    if (restored.isNotEmpty) {
+      lines.add('Restored: ${restored.join(", ")}');
+    }
+    if (skipped.isNotEmpty) {
+      lines.add('Skipped: ${skipped.join(", ")}');
+    }
+    if (errors.isNotEmpty) {
+      lines.add('Errors:');
+      errors.forEach((k, v) => lines.add('  $k: $v'));
+    }
+    return lines.join('\n');
+  }
+}
+
+/// Interface that data services must implement to support unified backup.
+///
+/// Services register themselves with [DataBackupService] using
+/// [registerService]. Each service provides a unique key, an export
+/// function that returns its data as a JSON-encodable map, and an
+/// import function that restores from a decoded map.
+typedef ExportFn = Map<String, dynamic> Function();
+typedef ImportFn = void Function(Map<String, dynamic> data);
+typedef AsyncImportFn = Future<void> Function(Map<String, dynamic> data);
+
+/// Unified backup and restore for all registered data services.
+///
+/// Usage:
+/// ```dart
+/// final backup = DataBackupService();
+/// backup.registerService(
+///   key: 'expenses',
+///   export: () => jsonDecode(expenseService.exportToJson()),
+///   import: (data) => expenseService.importFromJson(jsonEncode(data)),
+/// );
+/// // ... register more services
+///
+/// final json = backup.exportAll();    // full backup as JSON string
+/// final result = await backup.importAll(json);  // restore from backup
+/// ```
+class DataBackupService {
+  static const int backupVersion = 1;
+
+  /// Maximum number of services allowed (sanity check).
+  static const int maxServices = 200;
+
+  /// Maximum backup size in characters (50 MB of JSON text).
+  static const int maxBackupSize = 50 * 1024 * 1024;
+
+  final Map<String, _ServiceRegistration> _services = {};
+
+  /// Register a data service for unified backup.
+  ///
+  /// [key] must be unique and stable across app versions.
+  /// [export] returns the service's data as a JSON-encodable map.
+  /// [import_] restores the service from a decoded map.
+  /// [asyncImport] alternative async import for services that need
+  /// to persist to SharedPreferences during import.
+  void registerService({
+    required String key,
+    required ExportFn export,
+    ImportFn? import_,
+    AsyncImportFn? asyncImport,
+  }) {
+    if (key.isEmpty) {
+      throw ArgumentError('Service key must not be empty');
+    }
+    if (_services.length >= maxServices) {
+      throw StateError('Too many services registered (max $maxServices)');
+    }
+    _services[key] = _ServiceRegistration(
+      export: export,
+      import_: import_,
+      asyncImport: asyncImport,
+    );
+  }
+
+  /// Check which services support backup.
+  Map<String, bool> checkServiceSupport() {
+    return _services.map((key, _) => MapEntry(key, true));
+  }
+
+  /// List all registered service keys.
+  List<String> get registeredServices => _services.keys.toList()..sort();
+
+  /// Export all registered services as a single JSON string.
+  ///
+  /// The output contains a version number, timestamp, manifest of
+  /// included services, and each service's data keyed by its
+  /// registration key.
+  String exportAll() {
+    final serviceData = <String, dynamic>{};
+    final manifest = <String>[];
+
+    for (final entry in _services.entries) {
+      try {
+        serviceData[entry.key] = entry.value.export();
+        manifest.add(entry.key);
+      } catch (e) {
+        // Skip services that fail to export — don't block the whole
+        // backup because one service has bad state.
+        serviceData['_errors'] ??= <String, String>{};
+        (serviceData['_errors'] as Map<String, String>)[entry.key] =
+            e.toString();
+      }
+    }
+
+    final backup = <String, dynamic>{
+      'version': backupVersion,
+      'timestamp': DateTime.now().toUtc().toIso8601String(),
+      'manifest': manifest,
+      'services': serviceData,
+    };
+
+    return jsonEncode(backup);
+  }
+
+  /// Import all services from a backup JSON string.
+  ///
+  /// Services not present in the backup are skipped (not cleared).
+  /// Each service is imported independently — a failure in one
+  /// service doesn't affect others.
+  Future<BackupResult> importAll(String json) async {
+    if (json.length > maxBackupSize) {
+      throw ArgumentError(
+        'Backup file exceeds maximum size of '
+        '${(maxBackupSize / 1024 / 1024).toStringAsFixed(0)} MB.',
+      );
+    }
+
+    final data = jsonDecode(json) as Map<String, dynamic>;
+
+    // Version check
+    final version = data['version'] as int?;
+    if (version == null || version > backupVersion) {
+      throw ArgumentError(
+        'Unsupported backup version: $version '
+        '(this app supports up to v$backupVersion). '
+        'Please update the app.',
+      );
+    }
+
+    final services = data['services'] as Map<String, dynamic>?;
+    if (services == null) {
+      throw ArgumentError('Invalid backup: missing "services" section.');
+    }
+
+    final restored = <String>[];
+    final skipped = <String>[];
+    final errors = <String, String>{};
+
+    for (final key in _services.keys) {
+      if (!services.containsKey(key)) {
+        skipped.add(key);
+        continue;
+      }
+
+      try {
+        final serviceData = services[key] as Map<String, dynamic>;
+        final reg = _services[key]!;
+        if (reg.asyncImport != null) {
+          await reg.asyncImport!(serviceData);
+        } else if (reg.import_ != null) {
+          reg.import_!(serviceData);
+        } else {
+          skipped.add(key);
+          continue;
+        }
+        restored.add(key);
+      } catch (e) {
+        errors[key] = e.toString();
+      }
+    }
+
+    return BackupResult(
+      restored: restored,
+      skipped: skipped,
+      errors: errors,
+    );
+  }
+}
+
+class _ServiceRegistration {
+  final ExportFn export;
+  final ImportFn? import_;
+  final AsyncImportFn? asyncImport;
+
+  const _ServiceRegistration({
+    required this.export,
+    this.import_,
+    this.asyncImport,
+  });
+}

--- a/lib/core/services/habit_tracker_service.dart
+++ b/lib/core/services/habit_tracker_service.dart
@@ -10,6 +10,8 @@
 /// - Weekly summary with per-habit breakdown
 /// - Habit archiving (soft delete)
 
+import 'dart:convert';
+
 import '../../models/habit.dart';
 
 /// Stats for a single habit over a date range.
@@ -343,6 +345,64 @@ class HabitTrackerService {
       (c) => c.habitId == habitId && _dateOnly(c.date) == d,
     );
     return matches.isEmpty ? null : matches.first;
+  }
+
+  // ── Export / Import ──────────────────────────────────────────────
+
+  /// Maximum number of entries allowed via import.
+  static const int maxImportEntries = 100000;
+
+  /// Export all habits and completions as a JSON string.
+  String exportToJson() {
+    return jsonEncode({
+      'habits': _habits.map((h) => h.toJson()).toList(),
+      'completions': _completions.map((c) => c.toJson()).toList(),
+    });
+  }
+
+  /// Import habits and completions from a JSON string.
+  ///
+  /// Replaces all existing data. Parses into temporaries first so
+  /// malformed JSON doesn't wipe existing data.
+  void importFromJson(String jsonStr) {
+    final data = jsonDecode(jsonStr) as Map<String, dynamic>;
+    List<Habit>? parsedHabits;
+    List<HabitCompletion>? parsedCompletions;
+
+    if (data.containsKey('habits')) {
+      final list = data['habits'] as List<dynamic>;
+      if (list.length > maxImportEntries) {
+        throw ArgumentError(
+          'Import exceeds maximum of $maxImportEntries habits '
+          '(got ${list.length}).',
+        );
+      }
+      parsedHabits = list
+          .map((e) => Habit.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    if (data.containsKey('completions')) {
+      final list = data['completions'] as List<dynamic>;
+      if (list.length > maxImportEntries) {
+        throw ArgumentError(
+          'Import exceeds maximum of $maxImportEntries completions '
+          '(got ${list.length}).',
+        );
+      }
+      parsedCompletions = list
+          .map((e) => HabitCompletion.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+
+    // All parsed successfully — safe to apply.
+    if (parsedHabits != null) {
+      _habits.clear();
+      _habits.addAll(parsedHabits);
+    }
+    if (parsedCompletions != null) {
+      _completions.clear();
+      _completions.addAll(parsedCompletions);
+    }
   }
 
   static DateTime _dateOnly(DateTime dt) => DateTime(dt.year, dt.month, dt.day);

--- a/lib/core/services/mood_journal_service.dart
+++ b/lib/core/services/mood_journal_service.dart
@@ -119,6 +119,43 @@ class MoodJournalService {
     );
   }
 
+  // ── Export / Import ──────────────────────────────────────────────
+
+  /// Maximum number of entries allowed via import.
+  static const int maxImportEntries = 100000;
+
+  /// Export all mood entries as a JSON string.
+  String exportToJson() {
+    return jsonEncode({
+      'entries': _entries.map((e) => e.toJson()).toList(),
+    });
+  }
+
+  /// Import mood entries from a JSON string.
+  ///
+  /// Replaces all existing entries. Parse into temporaries first so
+  /// malformed JSON doesn't wipe existing data.
+  Future<void> importFromJson(String jsonStr) async {
+    final data = jsonDecode(jsonStr) as Map<String, dynamic>;
+    if (!data.containsKey('entries')) {
+      throw ArgumentError('Missing "entries" key in mood journal backup');
+    }
+    final list = data['entries'] as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}).',
+      );
+    }
+    final parsed = list
+        .map((e) => MoodEntry.fromJson(e as Map<String, dynamic>))
+        .toList();
+    // All parsed successfully — safe to apply.
+    _entries = parsed;
+    _entries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    await _save();
+  }
+
   /// Current streak of days with at least one entry.
   int currentStreak() {
     final now = DateTime.now();

--- a/lib/core/services/sleep_tracker_service.dart
+++ b/lib/core/services/sleep_tracker_service.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/sleep_entry.dart';
 
@@ -258,6 +259,43 @@ class SleepTrackerService {
     double avgStdDev = (_stdDev(bedVar) + _stdDev(wakeVar)) / 2;
     double score = 100 * (1 - (avgStdDev / 120).clamp(0, 1));
     return score.clamp(0, 100);
+  }
+
+  // ── Export / Import ──────────────────────────────────────────────
+
+  /// Maximum number of entries allowed via import.
+  static const int maxImportEntries = 100000;
+
+  /// Export all sleep entries as a JSON string.
+  String exportToJson() {
+    return jsonEncode({
+      'entries': _entries.map((e) => e.toJson()).toList(),
+    });
+  }
+
+  /// Import sleep entries from a JSON string.
+  ///
+  /// Replaces all existing entries. Parses into temporaries first so
+  /// malformed JSON doesn't wipe existing data.
+  Future<void> importFromJson(String jsonStr) async {
+    final data = jsonDecode(jsonStr) as Map<String, dynamic>;
+    if (!data.containsKey('entries')) {
+      throw ArgumentError('Missing "entries" key in sleep tracker backup');
+    }
+    final list = data['entries'] as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}).',
+      );
+    }
+    final parsed = list
+        .map((e) => SleepEntry.fromJson(e as Map<String, dynamic>))
+        .toList();
+    // All parsed successfully — safe to apply.
+    _entries = parsed;
+    _entries.sort((a, b) => b.wakeTime.compareTo(a.wakeTime));
+    await _save();
   }
 
   double _variance(List<double> values) {

--- a/test/data_backup_test.dart
+++ b/test/data_backup_test.dart
@@ -1,0 +1,265 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:everything/core/services/data_backup_service.dart';
+
+void main() {
+  group('DataBackupService', () {
+    late DataBackupService backupService;
+
+    setUp(() {
+      backupService = DataBackupService();
+    });
+
+    test('registerService and checkServiceSupport', () {
+      backupService.registerService(
+        key: 'test_service',
+        export: () => {'data': [1, 2, 3]},
+        import_: (data) {},
+      );
+
+      final support = backupService.checkServiceSupport();
+      expect(support['test_service'], isTrue);
+      expect(backupService.registeredServices, contains('test_service'));
+    });
+
+    test('registerService rejects empty key', () {
+      expect(
+        () => backupService.registerService(
+          key: '',
+          export: () => {},
+          import_: (data) {},
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('exportAll produces valid JSON with manifest', () {
+      backupService.registerService(
+        key: 'svc_a',
+        export: () => {'items': ['x', 'y']},
+        import_: (data) {},
+      );
+      backupService.registerService(
+        key: 'svc_b',
+        export: () => {'count': 42},
+        import_: (data) {},
+      );
+
+      final json = backupService.exportAll();
+      final parsed = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(parsed['version'], equals(DataBackupService.backupVersion));
+      expect(parsed['timestamp'], isNotEmpty);
+      expect(parsed['manifest'], containsAll(['svc_a', 'svc_b']));
+      expect(parsed['services']['svc_a']['items'], equals(['x', 'y']));
+      expect(parsed['services']['svc_b']['count'], equals(42));
+    });
+
+    test('importAll restores registered services', () async {
+      var restoredData = <String, dynamic>{};
+
+      backupService.registerService(
+        key: 'svc_a',
+        export: () => {'items': ['x']},
+        import_: (data) {
+          restoredData['svc_a'] = data;
+        },
+      );
+      backupService.registerService(
+        key: 'svc_b',
+        export: () => {'n': 1},
+        import_: (data) {
+          restoredData['svc_b'] = data;
+        },
+      );
+
+      final backup = jsonEncode({
+        'version': 1,
+        'timestamp': '2026-01-01T00:00:00Z',
+        'manifest': ['svc_a', 'svc_b'],
+        'services': {
+          'svc_a': {'items': ['restored']},
+          'svc_b': {'n': 99},
+        },
+      });
+
+      final result = await backupService.importAll(backup);
+
+      expect(result.restored, containsAll(['svc_a', 'svc_b']));
+      expect(result.skipped, isEmpty);
+      expect(result.hasErrors, isFalse);
+      expect(restoredData['svc_a']['items'], equals(['restored']));
+      expect(restoredData['svc_b']['n'], equals(99));
+    });
+
+    test('importAll skips services not in backup', () async {
+      backupService.registerService(
+        key: 'present',
+        export: () => {},
+        import_: (data) {},
+      );
+      backupService.registerService(
+        key: 'missing',
+        export: () => {},
+        import_: (data) {},
+      );
+
+      final backup = jsonEncode({
+        'version': 1,
+        'timestamp': '2026-01-01T00:00:00Z',
+        'manifest': ['present'],
+        'services': {
+          'present': {'ok': true},
+        },
+      });
+
+      final result = await backupService.importAll(backup);
+      expect(result.restored, contains('present'));
+      expect(result.skipped, contains('missing'));
+    });
+
+    test('importAll captures per-service errors without blocking others',
+        () async {
+      var restored = false;
+
+      backupService.registerService(
+        key: 'good',
+        export: () => {},
+        import_: (data) {
+          restored = true;
+        },
+      );
+      backupService.registerService(
+        key: 'bad',
+        export: () => {},
+        import_: (data) {
+          throw FormatException('corrupt data');
+        },
+      );
+
+      final backup = jsonEncode({
+        'version': 1,
+        'timestamp': '2026-01-01T00:00:00Z',
+        'manifest': ['good', 'bad'],
+        'services': {
+          'good': {'ok': true},
+          'bad': {'broken': true},
+        },
+      });
+
+      final result = await backupService.importAll(backup);
+      expect(restored, isTrue);
+      expect(result.restored, contains('good'));
+      expect(result.errors, containsPair('bad', contains('corrupt data')));
+    });
+
+    test('importAll rejects unsupported version', () async {
+      final backup = jsonEncode({
+        'version': 999,
+        'services': {},
+      });
+
+      expect(
+        () => backupService.importAll(backup),
+        throwsArgumentError,
+      );
+    });
+
+    test('importAll rejects oversized backup', () async {
+      // Create a string larger than maxBackupSize
+      final huge = 'x' * (DataBackupService.maxBackupSize + 1);
+      expect(
+        () => backupService.importAll(huge),
+        throwsArgumentError,
+      );
+    });
+
+    test('round-trip: export then import preserves data', () async {
+      var data = {'items': ['a', 'b', 'c'], 'count': 3};
+      var importedData = <String, dynamic>{};
+
+      backupService.registerService(
+        key: 'roundtrip',
+        export: () => Map<String, dynamic>.from(data),
+        import_: (d) {
+          importedData = d;
+        },
+      );
+
+      final exported = backupService.exportAll();
+      final result = await backupService.importAll(exported);
+
+      expect(result.restored, contains('roundtrip'));
+      expect(importedData['items'], equals(['a', 'b', 'c']));
+      expect(importedData['count'], equals(3));
+    });
+
+    test('asyncImport is used when provided', () async {
+      var asyncCalled = false;
+
+      backupService.registerService(
+        key: 'async_svc',
+        export: () => {'v': 1},
+        asyncImport: (data) async {
+          asyncCalled = true;
+        },
+      );
+
+      final backup = jsonEncode({
+        'version': 1,
+        'timestamp': '2026-01-01T00:00:00Z',
+        'manifest': ['async_svc'],
+        'services': {
+          'async_svc': {'v': 1},
+        },
+      });
+
+      await backupService.importAll(backup);
+      expect(asyncCalled, isTrue);
+    });
+
+    test('exportAll handles service export failure gracefully', () {
+      backupService.registerService(
+        key: 'failing',
+        export: () => throw StateError('database locked'),
+        import_: (data) {},
+      );
+      backupService.registerService(
+        key: 'working',
+        export: () => {'ok': true},
+        import_: (data) {},
+      );
+
+      final json = backupService.exportAll();
+      final parsed = jsonDecode(json) as Map<String, dynamic>;
+
+      expect(parsed['manifest'], contains('working'));
+      expect(parsed['manifest'], isNot(contains('failing')));
+      expect(parsed['services']['working']['ok'], isTrue);
+    });
+  });
+
+  group('BackupResult', () {
+    test('toString includes all sections', () {
+      final result = BackupResult(
+        restored: ['a', 'b'],
+        skipped: ['c'],
+        errors: {'d': 'failed'},
+      );
+
+      final str = result.toString();
+      expect(str, contains('Restored: a, b'));
+      expect(str, contains('Skipped: c'));
+      expect(str, contains('d: failed'));
+    });
+
+    test('hasErrors returns true when errors exist', () {
+      final result = BackupResult(
+        restored: [],
+        skipped: [],
+        errors: {'x': 'err'},
+      );
+      expect(result.hasErrors, isTrue);
+    });
+  });
+}

--- a/test/habit_tracker_test.dart
+++ b/test/habit_tracker_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:everything/models/habit.dart';
 import 'package:everything/core/services/habit_tracker_service.dart';
@@ -209,6 +210,36 @@ void main() {
       expect(summary.perfectDays, 7);
       expect(summary.overallRate, closeTo(1.0, 0.01));
       expect(summary.habitStats.length, 1);
+    });
+  });
+
+  group('Export / Import', () {
+    test('exportToJson round-trips habits and completions', () {
+      service.addHabit(dailyHabit);
+      service.logCompletion('meditate', DateTime(2026, 3, 2), note: 'good');
+
+      final json = service.exportToJson();
+      final parsed = jsonDecode(json) as Map<String, dynamic>;
+      expect(parsed['habits'], hasLength(1));
+      expect(parsed['completions'], hasLength(1));
+
+      // Import into a fresh service
+      final fresh = HabitTrackerService();
+      fresh.importFromJson(json);
+      expect(fresh.allHabits.length, 1);
+      expect(fresh.allHabits.first.name, 'Meditate');
+      expect(fresh.completions.length, 1);
+      expect(fresh.completions.first.note, 'good');
+    });
+
+    test('importFromJson rejects oversized input', () {
+      final huge = jsonEncode({
+        'habits': List.generate(100001, (i) => {
+          'id': 'h$i', 'name': 'H$i', 'frequency': 'daily',
+          'targetCount': 1, 'isActive': true,
+        }),
+      });
+      expect(() => service.importFromJson(huge), throwsArgumentError);
     });
   });
 }


### PR DESCRIPTION
## Summary

Implements a unified DataBackupService that enables single-file backup and restore across all data services, addressing #41.

### Changes

**New: DataBackupService** (lib/core/services/data_backup_service.dart)
- Registry pattern: services register with a key, export fn, and import fn
- xportAll() → single JSON string with version, timestamp, manifest, and all service data
- importAll(json) → restores each service independently with error isolation
- Safety: version validation, 50MB size limit, per-service error capture
- Supports both sync and async import (for SharedPreferences-backed services)

**Added export/import to services that lacked it:**
- MoodJournalService.exportToJson() / importFromJson()
- HabitTrackerService.exportToJson() / importFromJson()
- SleepTrackerService.exportToJson() / importFromJson()
- All include 100K entry import limit to prevent memory exhaustion

**Tests:**
- 11 test cases for DataBackupService (round-trip, error handling, version check, size limit, async import)
- Export/import round-trip tests for HabitTrackerService

### How to wire it up

\\\dart
final backup = DataBackupService();
backup.registerService(
  key: 'expenses',
  export: () => jsonDecode(expenseService.exportToJson()),
  import_: (data) => expenseService.importFromJson(jsonEncode(data)),
);
// Register all services...
final json = backup.exportAll();
final result = await backup.importAll(json);
\\\

Closes #41