### PR TITLE
feat: add persistence to 6 tracker screens + DataBackupService

### DIFF
--- a/lib/core/services/data_backup_service.dart
+++ b/lib/core/services/data_backup_service.dart
@@ -1,0 +1,191 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Result of a backup import operation.
+class BackupResult {
+  final int servicesRestored;
+  final int servicesFailed;
+  final List<String> errors;
+
+  const BackupResult({
+    required this.servicesRestored,
+    required this.servicesFailed,
+    this.errors = const [],
+  });
+
+  bool get success => servicesFailed == 0;
+
+  @override
+  String toString() =>
+      'BackupResult(restored: $servicesRestored, failed: $servicesFailed'
+      '${errors.isNotEmpty ? ', errors: $errors' : ''})';
+}
+
+/// Unified data backup/restore service for the Everything app.
+///
+/// Aggregates all service data stored in SharedPreferences into a single
+/// JSON backup that can be exported and imported to restore all user data.
+///
+/// Usage:
+/// ```dart
+/// final backup = DataBackupService();
+/// final json = await backup.exportAll();  // Save this string to a file
+/// final result = await backup.importAll(json);  // Restore from backup
+/// ```
+class DataBackupService {
+  /// Version of the backup format for future compatibility.
+  static const int backupVersion = 1;
+
+  /// All known SharedPreferences keys used by services in the app.
+  /// When adding a new service with persistence, add its key here.
+  static const List<String> _serviceKeys = [
+    // Services with SharedPreferences persistence
+    'mood_journal_entries',
+    'sleep_tracker_entries',
+    'habit_tracker_habits',
+    'habit_tracker_completions',
+    'water_tracker_entries',
+    'expense_tracker_entries',
+    'expense_tracker_budgets',
+    'gratitude_journal_entries',
+    'meal_tracker_entries',
+    'workout_tracker_entries',
+    'skill_tracker_entries',
+    'contact_tracker_entries',
+    'decision_journal_entries',
+    'energy_tracker_entries',
+    'meditation_tracker_entries',
+    'reading_list_entries',
+    'chore_tracker_entries',
+    'goals_tracker_entries',
+    'medication_tracker_entries',
+    'pet_care_tracker_entries',
+    // Newly persisted services
+    'subscription_tracker_data',
+    'screen_time_tracker_data',
+    'grocery_list_data',
+    'savings_goal_data',
+    'home_inventory_data',
+    'warranty_tracker_data',
+    // Template and secure storage
+    'template_service_templates',
+  ];
+
+  /// Export all service data as a single JSON string.
+  ///
+  /// Returns a JSON string containing all persisted service data,
+  /// along with metadata (version, timestamp, service count).
+  Future<String> exportAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    final services = <String, dynamic>{};
+
+    for (final key in _serviceKeys) {
+      final value = prefs.getString(key);
+      if (value != null && value.isNotEmpty) {
+        services[key] = value;
+      }
+    }
+
+    final backup = {
+      'version': backupVersion,
+      'timestamp': DateTime.now().toIso8601String(),
+      'serviceCount': services.length,
+      'services': services,
+    };
+
+    return jsonEncode(backup);
+  }
+
+  /// Import all service data from a backup JSON string.
+  ///
+  /// Restores each service's data from the backup. Existing data for
+  /// each service is replaced (not merged).
+  Future<BackupResult> importAll(String json) async {
+    final prefs = await SharedPreferences.getInstance();
+    int restored = 0;
+    int failed = 0;
+    final errors = <String>[];
+
+    try {
+      final backup = jsonDecode(json) as Map<String, dynamic>;
+
+      // Version check
+      final version = backup['version'] as int? ?? 0;
+      if (version > backupVersion) {
+        return BackupResult(
+          servicesRestored: 0,
+          servicesFailed: 1,
+          errors: [
+            'Backup version $version is newer than supported version $backupVersion'
+          ],
+        );
+      }
+
+      final services = backup['services'] as Map<String, dynamic>?;
+      if (services == null) {
+        return const BackupResult(
+          servicesRestored: 0,
+          servicesFailed: 1,
+          errors: ['Invalid backup format: missing services data'],
+        );
+      }
+
+      for (final entry in services.entries) {
+        try {
+          final value = entry.value as String;
+          // Validate it's valid JSON before storing
+          jsonDecode(value);
+          await prefs.setString(entry.key, value);
+          restored++;
+        } catch (e) {
+          failed++;
+          errors.add('${entry.key}: $e');
+        }
+      }
+    } catch (e) {
+      return BackupResult(
+        servicesRestored: restored,
+        servicesFailed: failed + 1,
+        errors: [...errors, 'Parse error: $e'],
+      );
+    }
+
+    return BackupResult(
+      servicesRestored: restored,
+      servicesFailed: failed,
+      errors: errors,
+    );
+  }
+
+  /// Check which services have persisted data.
+  Future<Map<String, bool>> checkServiceSupport() async {
+    final prefs = await SharedPreferences.getInstance();
+    final result = <String, bool>{};
+    for (final key in _serviceKeys) {
+      final value = prefs.getString(key);
+      result[key] = value != null && value.isNotEmpty;
+    }
+    return result;
+  }
+
+  /// Clear all persisted service data.
+  Future<void> clearAll() async {
+    final prefs = await SharedPreferences.getInstance();
+    for (final key in _serviceKeys) {
+      await prefs.remove(key);
+    }
+  }
+
+  /// Get the total size of all persisted data in bytes (approximate).
+  Future<int> estimateDataSize() async {
+    final prefs = await SharedPreferences.getInstance();
+    int totalBytes = 0;
+    for (final key in _serviceKeys) {
+      final value = prefs.getString(key);
+      if (value != null) {
+        totalBytes += value.length;
+      }
+    }
+    return totalBytes;
+  }
+}

--- a/lib/views/home/grocery_list_screen.dart
+++ b/lib/views/home/grocery_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/grocery_list_service.dart';
 import '../../models/grocery_item.dart';
 
@@ -13,6 +14,7 @@ class GroceryListScreen extends StatefulWidget {
 
 class _GroceryListScreenState extends State<GroceryListScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'grocery_list_data';
   late final GroceryListService _service;
   late TabController _tabController;
   String? _selectedListId;
@@ -22,12 +24,45 @@ class _GroceryListScreenState extends State<GroceryListScreen>
     super.initState();
     _service = GroceryListService();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
   }
 
   @override
   void dispose() {
     _tabController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.importFromJson(data);
+        if (_service.lists.isNotEmpty) {
+          _selectedListId = _service.lists.first.id;
+          if (mounted) setState(() {});
+          return;
+        }
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
+  }
+
+  /// Wrapper that calls setState and persists changes.
+  void _mutate(VoidCallback fn) {
+    setState(fn);
+    _saveData();
   }
 
   void _createList() {

--- a/lib/views/home/home_inventory_screen.dart
+++ b/lib/views/home/home_inventory_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/home_inventory_service.dart';
 import '../../models/inventory_item.dart';
 
@@ -13,6 +14,7 @@ class HomeInventoryScreen extends StatefulWidget {
 
 class _HomeInventoryScreenState extends State<HomeInventoryScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'home_inventory_data';
   final HomeInventoryService _service = HomeInventoryService();
   late TabController _tabController;
   InventoryRoom? _filterRoom;
@@ -24,7 +26,35 @@ class _HomeInventoryScreenState extends State<HomeInventoryScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.importFromJson(data);
+        if (_service.items.isNotEmpty) {
+          _nextId = _service.items.length + 1;
+          if (mounted) setState(() {});
+          return;
+        }
+      } catch (_) {}
+    }
     _loadSampleData();
+    _saveData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
+  }
+
+  @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
   }
 
   @override

--- a/lib/views/home/savings_goal_screen.dart
+++ b/lib/views/home/savings_goal_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/savings_goal_service.dart';
 import '../../models/savings_goal.dart';
 
@@ -13,6 +14,7 @@ class SavingsGoalScreen extends StatefulWidget {
 
 class _SavingsGoalScreenState extends State<SavingsGoalScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'savings_goal_data';
   final SavingsGoalService _service = SavingsGoalService();
   late TabController _tabController;
   SavingsGoalCategory? _filterCategory;
@@ -22,6 +24,29 @@ class _SavingsGoalScreenState extends State<SavingsGoalScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.importJson(data);
+        if (mounted) setState(() {});
+      } catch (_) {}
+    }
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportJson());
+  }
+
+  @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
   }
 
   @override

--- a/lib/views/home/screen_time_tracker_screen.dart
+++ b/lib/views/home/screen_time_tracker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/screen_time_tracker_service.dart';
 import '../../models/screen_time_entry.dart';
 
@@ -14,6 +15,7 @@ class ScreenTimeTrackerScreen extends StatefulWidget {
 
 class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'screen_time_tracker_data';
   final ScreenTimeTrackerService _service = ScreenTimeTrackerService();
   late TabController _tabController;
   DateTime _selectedDate = DateTime.now();
@@ -23,7 +25,29 @@ class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadPersistedData();
+  }
+
+  Future<void> _loadPersistedData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.importFromJson(data);
+        if (_service.entries.isNotEmpty) {
+          _initialized = true;
+          if (mounted) setState(() {});
+          return;
+        }
+      } catch (_) {}
+    }
     _loadDemoData();
+    await _saveData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
   }
 
   void _loadDemoData() {
@@ -76,6 +100,12 @@ class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
   }
 
   @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
+  }
+
+  @override
   void dispose() {
     _tabController.dispose();
     super.dispose();
@@ -100,11 +130,11 @@ class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
       body: TabBarView(
         controller: _tabController,
         children: [
-          _LogTab(service: _service, onLogged: () => setState(() {})),
+          _LogTab(service: _service, onLogged: () { setState(() {}); _saveData(); }),
           _TodayTab(
             service: _service, selectedDate: _selectedDate,
             onDateChanged: (d) => setState(() => _selectedDate = d),
-            onChanged: () => setState(() {}),
+            onChanged: () { setState(() {}); _saveData(); },
           ),
           _BreakdownTab(service: _service),
           _InsightsTab(service: _service),

--- a/lib/views/home/subscription_tracker_screen.dart
+++ b/lib/views/home/subscription_tracker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/subscription_tracker_service.dart';
 import '../../models/subscription_entry.dart';
 
@@ -14,6 +15,7 @@ class SubscriptionTrackerScreen extends StatefulWidget {
 
 class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'subscription_tracker_data';
   final SubscriptionTrackerService _service = SubscriptionTrackerService();
   late TabController _tabController;
   SubscriptionCategory? _filterCategory;
@@ -25,13 +27,44 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
-    _loadSampleData();
+    _loadData();
+  }
+
+  @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
   }
 
   @override
   void dispose() {
     _tabController.dispose();
     super.dispose();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.loadFromJson(data);
+        final subs = _service.subscriptions;
+        if (subs.isNotEmpty) {
+          _nextId = subs.length + 1;
+          if (mounted) setState(() {});
+          return;
+        }
+      } catch (_) {
+        // Fall through to sample data on parse error.
+      }
+    }
+    _loadSampleData();
+    await _saveData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.toJson());
   }
 
   void _loadSampleData() {
@@ -329,6 +362,7 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
       }
     });
     if (action != 'edit') {
+      _saveData();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('${sub.name}: $action'),
@@ -837,6 +871,7 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
                     ));
                   }
                 });
+                _saveData();
                 Navigator.pop(ctx);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(

--- a/lib/views/home/warranty_tracker_screen.dart
+++ b/lib/views/home/warranty_tracker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/warranty_tracker_service.dart';
 import '../../models/warranty_entry.dart';
 
@@ -13,6 +14,7 @@ class WarrantyTrackerScreen extends StatefulWidget {
 
 class _WarrantyTrackerScreenState extends State<WarrantyTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'warranty_tracker_data';
   final WarrantyTrackerService _service = WarrantyTrackerService();
   late TabController _tabController;
   WarrantyCategory? _filterCategory;
@@ -23,7 +25,35 @@ class _WarrantyTrackerScreenState extends State<WarrantyTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_storageKey);
+    if (data != null && data.isNotEmpty) {
+      try {
+        _service.importFromJson(data);
+        if (_service.warranties.isNotEmpty) {
+          _nextId = _service.warranties.length + 1;
+          if (mounted) setState(() {});
+          return;
+        }
+      } catch (_) {}
+    }
     _loadSampleData();
+    _saveData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
+  }
+
+  @override
+  void deactivate() {
+    _saveData();
+    super.deactivate();
   }
 
   @override


### PR DESCRIPTION
Adds SharedPreferences persistence to 6 tracker screens that previously lost all data on app restart, plus a unified DataBackupService for backup/restore.

**Screens with new persistence:** SubscriptionTracker, ScreenTimeTracker, GroceryList, SavingsGoal, HomeInventory, WarrantyTracker

**How it works:** Each screen loads persisted data on init via SharedPreferences, saves automatically via deactivate() lifecycle hook, and falls back to sample data on first launch.

**DataBackupService** (lib/core/services/data_backup_service.dart): exportAll(), importAll(), checkServiceSupport(), estimateDataSize()

Partially fixes #42, Fixes #41