### PR TITLE
feat: add SharedPreferences persistence to 3 tracker screens (partial fix #42)

### DIFF
--- a/lib/views/home/home_inventory_screen.dart
+++ b/lib/views/home/home_inventory_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/home_inventory_service.dart';
 import '../../models/inventory_item.dart';
 
@@ -13,6 +14,7 @@ class HomeInventoryScreen extends StatefulWidget {
 
 class _HomeInventoryScreenState extends State<HomeInventoryScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'home_inventory_data';
   final HomeInventoryService _service = HomeInventoryService();
   late TabController _tabController;
   InventoryRoom? _filterRoom;
@@ -24,7 +26,26 @@ class _HomeInventoryScreenState extends State<HomeInventoryScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.importFromJson(json);
+        _nextId = _service.items.length + 1;
+        setState(() {});
+        return;
+      } catch (_) {}
+    }
     _loadSampleData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
   }
 
   @override
@@ -236,6 +257,7 @@ class _HomeInventoryScreenState extends State<HomeInventoryScreen>
                                 if (v == 'delete') {
                                   setState(
                                       () => _service.removeItem(item.id));
+                                  _saveData();
                                 }
                               },
                               itemBuilder: (_) => [
@@ -557,6 +579,7 @@ class _HomeInventoryScreenState extends State<HomeInventoryScreen>
                         : serialCtrl.text.trim(),
                   ));
                 });
+                _saveData();
                 Navigator.pop(ctx);
               },
               child: const Text('Add'),

--- a/lib/views/home/screen_time_tracker_screen.dart
+++ b/lib/views/home/screen_time_tracker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/screen_time_tracker_service.dart';
 import '../../models/screen_time_entry.dart';
 
@@ -14,6 +15,7 @@ class ScreenTimeTrackerScreen extends StatefulWidget {
 
 class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'screen_time_tracker_data';
   final ScreenTimeTrackerService _service = ScreenTimeTrackerService();
   late TabController _tabController;
   DateTime _selectedDate = DateTime.now();
@@ -23,7 +25,26 @@ class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.importFromJson(json);
+        _initialized = true;
+        setState(() {});
+        return;
+      } catch (_) {}
+    }
     _loadDemoData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.exportToJson());
   }
 
   void _loadDemoData() {
@@ -100,11 +121,11 @@ class _ScreenTimeTrackerScreenState extends State<ScreenTimeTrackerScreen>
       body: TabBarView(
         controller: _tabController,
         children: [
-          _LogTab(service: _service, onLogged: () => setState(() {})),
+          _LogTab(service: _service, onLogged: () { setState(() {}); _saveData(); }),
           _TodayTab(
             service: _service, selectedDate: _selectedDate,
             onDateChanged: (d) => setState(() => _selectedDate = d),
-            onChanged: () => setState(() {}),
+            onChanged: () { setState(() {}); _saveData(); },
           ),
           _BreakdownTab(service: _service),
           _InsightsTab(service: _service),

--- a/lib/views/home/subscription_tracker_screen.dart
+++ b/lib/views/home/subscription_tracker_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/services/subscription_tracker_service.dart';
 import '../../models/subscription_entry.dart';
 
@@ -14,6 +15,7 @@ class SubscriptionTrackerScreen extends StatefulWidget {
 
 class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
     with SingleTickerProviderStateMixin {
+  static const _storageKey = 'subscription_tracker_data';
   final SubscriptionTrackerService _service = SubscriptionTrackerService();
   late TabController _tabController;
   SubscriptionCategory? _filterCategory;
@@ -25,7 +27,26 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this);
+    _loadData();
+  }
+
+  Future<void> _loadData() async {
+    final prefs = await SharedPreferences.getInstance();
+    final json = prefs.getString(_storageKey);
+    if (json != null && json.isNotEmpty) {
+      try {
+        _service.loadFromJson(json);
+        _nextId = _service.subscriptions.length + 1;
+        setState(() {});
+        return;
+      } catch (_) {}
+    }
     _loadSampleData();
+  }
+
+  Future<void> _saveData() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_storageKey, _service.toJson());
   }
 
   @override
@@ -329,6 +350,7 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
       }
     });
     if (action != 'edit') {
+      _saveData();
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text('${sub.name}: $action'),
@@ -837,6 +859,7 @@ class _SubscriptionTrackerScreenState extends State<SubscriptionTrackerScreen>
                     ));
                   }
                 });
+                _saveData();
                 Navigator.pop(ctx);
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(


### PR DESCRIPTION
Adds SharedPreferences persistence to SubscriptionTrackerScreen, ScreenTimeTrackerScreen, and HomeInventoryScreen. Each screen loads persisted data on startup (falls back to demo data if none), and saves after every mutation. Partial fix for #42.