### PR TITLE
feat: PackingListService — trip packing lists with templates

### DIFF
--- a/lib/core/services/packing_list_service.dart
+++ b/lib/core/services/packing_list_service.dart
@@ -1,0 +1,596 @@
+/// Packing List Service — create, manage, and reuse packing lists with
+/// trip-type templates, weight tracking, and progress monitoring.
+
+import 'dart:convert';
+import '../../models/packing_item.dart';
+
+// ── Template Data ─────────────────────────────────────────────────────
+
+/// Built-in packing suggestions by template type.
+const Map<PackingTemplateType, List<_TemplateItem>> _builtInTemplates = {
+  PackingTemplateType.beach: [
+    _TemplateItem('Swimsuit', PackingCategory.clothing, PackingPriority.essential, 200),
+    _TemplateItem('Sunscreen', PackingCategory.toiletries, PackingPriority.essential, 150),
+    _TemplateItem('Sunglasses', PackingCategory.accessories, PackingPriority.essential, 30),
+    _TemplateItem('Beach towel', PackingCategory.accessories, PackingPriority.essential, 500),
+    _TemplateItem('Flip flops', PackingCategory.clothing, PackingPriority.essential, 300),
+    _TemplateItem('Hat', PackingCategory.accessories, PackingPriority.important, 100),
+    _TemplateItem('Light dress/shorts', PackingCategory.clothing, PackingPriority.important, 200),
+    _TemplateItem('Aloe vera gel', PackingCategory.toiletries, PackingPriority.optional, 100),
+    _TemplateItem('Snorkel gear', PackingCategory.entertainment, PackingPriority.optional, 400),
+    _TemplateItem('Waterproof phone case', PackingCategory.electronics, PackingPriority.optional, 50),
+  ],
+  PackingTemplateType.business: [
+    _TemplateItem('Suit/blazer', PackingCategory.clothing, PackingPriority.essential, 1200),
+    _TemplateItem('Dress shoes', PackingCategory.clothing, PackingPriority.essential, 800),
+    _TemplateItem('Dress shirts', PackingCategory.clothing, PackingPriority.essential, 250),
+    _TemplateItem('Laptop', PackingCategory.electronics, PackingPriority.essential, 1500),
+    _TemplateItem('Laptop charger', PackingCategory.electronics, PackingPriority.essential, 300),
+    _TemplateItem('Business cards', PackingCategory.documents, PackingPriority.important, 30),
+    _TemplateItem('Notebook & pen', PackingCategory.accessories, PackingPriority.important, 200),
+    _TemplateItem('Tie/scarf', PackingCategory.accessories, PackingPriority.important, 100),
+    _TemplateItem('Portable charger', PackingCategory.electronics, PackingPriority.optional, 200),
+    _TemplateItem('Travel iron', PackingCategory.accessories, PackingPriority.optional, 500),
+  ],
+  PackingTemplateType.camping: [
+    _TemplateItem('Tent', PackingCategory.accessories, PackingPriority.essential, 3000),
+    _TemplateItem('Sleeping bag', PackingCategory.accessories, PackingPriority.essential, 1500),
+    _TemplateItem('Sleeping pad', PackingCategory.accessories, PackingPriority.essential, 500),
+    _TemplateItem('Headlamp', PackingCategory.electronics, PackingPriority.essential, 100),
+    _TemplateItem('First aid kit', PackingCategory.medications, PackingPriority.essential, 300),
+    _TemplateItem('Water bottle', PackingCategory.food, PackingPriority.essential, 200),
+    _TemplateItem('Camp stove', PackingCategory.food, PackingPriority.important, 800),
+    _TemplateItem('Insect repellent', PackingCategory.toiletries, PackingPriority.important, 100),
+    _TemplateItem('Multi-tool', PackingCategory.accessories, PackingPriority.important, 200),
+    _TemplateItem('Hiking boots', PackingCategory.clothing, PackingPriority.essential, 900),
+    _TemplateItem('Rain jacket', PackingCategory.clothing, PackingPriority.important, 400),
+    _TemplateItem('Firestarter', PackingCategory.accessories, PackingPriority.optional, 50),
+  ],
+  PackingTemplateType.winter: [
+    _TemplateItem('Winter coat', PackingCategory.clothing, PackingPriority.essential, 1500),
+    _TemplateItem('Thermal underwear', PackingCategory.clothing, PackingPriority.essential, 300),
+    _TemplateItem('Wool socks', PackingCategory.clothing, PackingPriority.essential, 80),
+    _TemplateItem('Gloves', PackingCategory.accessories, PackingPriority.essential, 150),
+    _TemplateItem('Scarf', PackingCategory.accessories, PackingPriority.essential, 200),
+    _TemplateItem('Beanie', PackingCategory.accessories, PackingPriority.essential, 80),
+    _TemplateItem('Snow boots', PackingCategory.clothing, PackingPriority.essential, 1200),
+    _TemplateItem('Lip balm', PackingCategory.toiletries, PackingPriority.important, 10),
+    _TemplateItem('Hand warmers', PackingCategory.accessories, PackingPriority.optional, 50),
+    _TemplateItem('Ski goggles', PackingCategory.accessories, PackingPriority.optional, 200),
+  ],
+  PackingTemplateType.backpacking: [
+    _TemplateItem('Backpack (40-65L)', PackingCategory.accessories, PackingPriority.essential, 1500),
+    _TemplateItem('Quick-dry clothes', PackingCategory.clothing, PackingPriority.essential, 300),
+    _TemplateItem('Travel towel', PackingCategory.toiletries, PackingPriority.essential, 150),
+    _TemplateItem('Passport', PackingCategory.documents, PackingPriority.essential, 50),
+    _TemplateItem('Travel insurance docs', PackingCategory.documents, PackingPriority.essential, 10),
+    _TemplateItem('Padlock', PackingCategory.accessories, PackingPriority.important, 100),
+    _TemplateItem('Universal adapter', PackingCategory.electronics, PackingPriority.important, 120),
+    _TemplateItem('Packing cubes', PackingCategory.accessories, PackingPriority.important, 200),
+    _TemplateItem('Dry bag', PackingCategory.accessories, PackingPriority.optional, 100),
+    _TemplateItem('Clothesline', PackingCategory.accessories, PackingPriority.optional, 30),
+  ],
+  PackingTemplateType.weekend: [
+    _TemplateItem('Change of clothes', PackingCategory.clothing, PackingPriority.essential, 500),
+    _TemplateItem('Toiletry bag', PackingCategory.toiletries, PackingPriority.essential, 300),
+    _TemplateItem('Phone charger', PackingCategory.electronics, PackingPriority.essential, 50),
+    _TemplateItem('Wallet/ID', PackingCategory.documents, PackingPriority.essential, 50),
+    _TemplateItem('Sleepwear', PackingCategory.clothing, PackingPriority.important, 200),
+    _TemplateItem('Snacks', PackingCategory.food, PackingPriority.optional, 200),
+    _TemplateItem('Book/Kindle', PackingCategory.entertainment, PackingPriority.optional, 200),
+  ],
+  PackingTemplateType.family: [
+    _TemplateItem('Kids clothes', PackingCategory.clothing, PackingPriority.essential, 500),
+    _TemplateItem('Diapers/wipes', PackingCategory.toiletries, PackingPriority.essential, 400),
+    _TemplateItem('Snacks', PackingCategory.food, PackingPriority.essential, 300),
+    _TemplateItem('Car seat', PackingCategory.accessories, PackingPriority.essential, 5000),
+    _TemplateItem('Stroller', PackingCategory.accessories, PackingPriority.important, 7000),
+    _TemplateItem('Toys/games', PackingCategory.entertainment, PackingPriority.important, 500),
+    _TemplateItem('First aid kit', PackingCategory.medications, PackingPriority.important, 300),
+    _TemplateItem('Tablet with movies', PackingCategory.electronics, PackingPriority.optional, 500),
+    _TemplateItem('Baby monitor', PackingCategory.electronics, PackingPriority.optional, 200),
+  ],
+};
+
+/// Common essentials added to every list regardless of template.
+const List<_TemplateItem> _universalEssentials = [
+  _TemplateItem('Underwear', PackingCategory.clothing, PackingPriority.essential, 60),
+  _TemplateItem('Socks', PackingCategory.clothing, PackingPriority.essential, 40),
+  _TemplateItem('T-shirts', PackingCategory.clothing, PackingPriority.essential, 150),
+  _TemplateItem('Toothbrush & paste', PackingCategory.toiletries, PackingPriority.essential, 80),
+  _TemplateItem('Deodorant', PackingCategory.toiletries, PackingPriority.essential, 70),
+  _TemplateItem('Phone charger', PackingCategory.electronics, PackingPriority.essential, 50),
+  _TemplateItem('Medications', PackingCategory.medications, PackingPriority.essential, 50),
+  _TemplateItem('ID/passport', PackingCategory.documents, PackingPriority.essential, 50),
+];
+
+class _TemplateItem {
+  final String name;
+  final PackingCategory category;
+  final PackingPriority priority;
+  final double weightGrams;
+  const _TemplateItem(this.name, this.category, this.priority, this.weightGrams);
+}
+
+// ── Result Classes ────────────────────────────────────────────────────
+
+/// Summary statistics across all packing lists.
+class PackingSummary {
+  final int totalLists;
+  final int activeLists;
+  final int archivedLists;
+  final int fullyPackedLists;
+  final int totalItems;
+  final int packedItems;
+  final double overallProgressPercent;
+  final double totalWeightKg;
+  final Map<PackingCategory, int> itemsByCategory;
+  final PackingList? nextDeparture;
+
+  const PackingSummary({
+    required this.totalLists,
+    required this.activeLists,
+    required this.archivedLists,
+    required this.fullyPackedLists,
+    required this.totalItems,
+    required this.packedItems,
+    required this.overallProgressPercent,
+    required this.totalWeightKg,
+    required this.itemsByCategory,
+    this.nextDeparture,
+  });
+}
+
+/// Weight breakdown by category.
+class WeightBreakdown {
+  final double totalWeightKg;
+  final Map<PackingCategory, double> byCategory;
+  final String heaviestItem;
+  final double heaviestItemWeightGrams;
+  final int itemsWithoutWeight;
+
+  const WeightBreakdown({
+    required this.totalWeightKg,
+    required this.byCategory,
+    required this.heaviestItem,
+    required this.heaviestItemWeightGrams,
+    required this.itemsWithoutWeight,
+  });
+}
+
+/// Packing readiness check.
+class ReadinessCheck {
+  final String listName;
+  final double progressPercent;
+  final List<PackingItem> essentialUnpacked;
+  final List<PackingItem> importantUnpacked;
+  final List<PackingItem> optionalUnpacked;
+  final bool isReady;
+  final int daysUntilDeparture;
+
+  const ReadinessCheck({
+    required this.listName,
+    required this.progressPercent,
+    required this.essentialUnpacked,
+    required this.importantUnpacked,
+    required this.optionalUnpacked,
+    required this.isReady,
+    required this.daysUntilDeparture,
+  });
+}
+
+// ── Service ───────────────────────────────────────────────────────────
+
+/// Main service for packing list management.
+class PackingListService {
+  final List<PackingList> _lists;
+  int _nextId;
+
+  PackingListService({List<PackingList>? lists})
+      : _lists = lists ?? [],
+        _nextId = 1;
+
+  List<PackingList> get allLists => List.unmodifiable(_lists);
+  List<PackingList> get activeLists =>
+      _lists.where((l) => !l.isArchived).toList();
+  List<PackingList> get archivedLists =>
+      _lists.where((l) => l.isArchived).toList();
+
+  String _genId() => 'pkg_${_nextId++}_${DateTime.now().millisecondsSinceEpoch}';
+
+  // ── CRUD ──────────────────────────────────────────────────────
+
+  /// Create a new packing list from a template.
+  /// Populates universal essentials + template-specific items.
+  /// For multi-day trips, adjusts clothing quantities.
+  PackingList createFromTemplate({
+    required String name,
+    required PackingTemplateType templateType,
+    int tripDays = 1,
+    DateTime? departureDate,
+  }) {
+    final items = <PackingItem>[];
+    final addedNames = <String>{};
+
+    // Add universal essentials first
+    for (final t in _universalEssentials) {
+      int qty = 1;
+      // Scale clothing by trip days
+      if (t.category == PackingCategory.clothing && tripDays > 1) {
+        qty = tripDays;
+      }
+      items.add(PackingItem(
+        id: _genId(),
+        name: t.name,
+        category: t.category,
+        priority: t.priority,
+        quantity: qty,
+        weightGrams: t.weightGrams,
+      ));
+      addedNames.add(t.name.toLowerCase());
+    }
+
+    // Add template-specific items (skip duplicates)
+    final templateItems = _builtInTemplates[templateType] ?? [];
+    for (final t in templateItems) {
+      if (addedNames.contains(t.name.toLowerCase())) continue;
+      items.add(PackingItem(
+        id: _genId(),
+        name: t.name,
+        category: t.category,
+        priority: t.priority,
+        quantity: 1,
+        weightGrams: t.weightGrams,
+      ));
+      addedNames.add(t.name.toLowerCase());
+    }
+
+    final list = PackingList(
+      id: _genId(),
+      name: name,
+      templateType: templateType,
+      tripDays: tripDays,
+      createdAt: DateTime.now(),
+      departureDate: departureDate,
+      items: items,
+    );
+    _lists.add(list);
+    return list;
+  }
+
+  /// Create an empty packing list.
+  PackingList createEmpty({required String name, DateTime? departureDate}) {
+    final list = PackingList(
+      id: _genId(),
+      name: name,
+      templateType: PackingTemplateType.custom,
+      createdAt: DateTime.now(),
+      departureDate: departureDate,
+    );
+    _lists.add(list);
+    return list;
+  }
+
+  /// Get a list by ID.
+  PackingList? getList(String listId) {
+    for (final l in _lists) {
+      if (l.id == listId) return l;
+    }
+    return null;
+  }
+
+  /// Delete a list.
+  bool deleteList(String listId) {
+    final before = _lists.length;
+    _lists.removeWhere((l) => l.id == listId);
+    return _lists.length < before;
+  }
+
+  /// Archive a list (mark as done/past trip).
+  PackingList? archiveList(String listId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final updated = _lists[idx].copyWith(isArchived: true);
+    _lists[idx] = updated;
+    return updated;
+  }
+
+  /// Unarchive a list.
+  PackingList? unarchiveList(String listId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final updated = _lists[idx].copyWith(isArchived: false);
+    _lists[idx] = updated;
+    return updated;
+  }
+
+  // ── Item Management ───────────────────────────────────────────
+
+  /// Add an item to a list.
+  PackingItem? addItem(String listId, {
+    required String name,
+    required PackingCategory category,
+    PackingPriority priority = PackingPriority.important,
+    int quantity = 1,
+    double? weightGrams,
+    String? notes,
+  }) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final item = PackingItem(
+      id: _genId(),
+      name: name,
+      category: category,
+      priority: priority,
+      quantity: quantity,
+      weightGrams: weightGrams,
+      notes: notes,
+    );
+    final updated = _lists[idx].copyWith(
+      items: [..._lists[idx].items, item],
+    );
+    _lists[idx] = updated;
+    return item;
+  }
+
+  /// Remove an item from a list.
+  bool removeItem(String listId, String itemId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return false;
+    final newItems = _lists[idx].items.where((i) => i.id != itemId).toList();
+    if (newItems.length == _lists[idx].items.length) return false;
+    _lists[idx] = _lists[idx].copyWith(items: newItems);
+    return true;
+  }
+
+  /// Toggle an item's packed status.
+  PackingItem? togglePacked(String listId, String itemId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final items = _lists[idx].items.toList();
+    final itemIdx = items.indexWhere((i) => i.id == itemId);
+    if (itemIdx < 0) return null;
+    final toggled = items[itemIdx].copyWith(isPacked: !items[itemIdx].isPacked);
+    items[itemIdx] = toggled;
+    _lists[idx] = _lists[idx].copyWith(items: items);
+    return toggled;
+  }
+
+  /// Mark all items as packed.
+  PackingList? packAll(String listId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final items = _lists[idx].items.map((i) => i.copyWith(isPacked: true)).toList();
+    _lists[idx] = _lists[idx].copyWith(items: items);
+    return _lists[idx];
+  }
+
+  /// Unpack all items (reset).
+  PackingList? unpackAll(String listId) {
+    final idx = _lists.indexWhere((l) => l.id == listId);
+    if (idx < 0) return null;
+    final items = _lists[idx].items.map((i) => i.copyWith(isPacked: false)).toList();
+    _lists[idx] = _lists[idx].copyWith(items: items);
+    return _lists[idx];
+  }
+
+  // ── Duplicate / Reuse ─────────────────────────────────────────
+
+  /// Duplicate a list (all items unpacked) for a new trip.
+  PackingList? duplicateList(String listId, {required String newName, DateTime? departureDate}) {
+    final source = getList(listId);
+    if (source == null) return null;
+    final newItems = source.items.map((i) => PackingItem(
+      id: _genId(),
+      name: i.name,
+      category: i.category,
+      priority: i.priority,
+      quantity: i.quantity,
+      weightGrams: i.weightGrams,
+      isPacked: false,
+      notes: i.notes,
+    )).toList();
+    final newList = PackingList(
+      id: _genId(),
+      name: newName,
+      templateType: source.templateType,
+      tripDays: source.tripDays,
+      createdAt: DateTime.now(),
+      departureDate: departureDate,
+      items: newItems,
+    );
+    _lists.add(newList);
+    return newList;
+  }
+
+  // ── Analytics ─────────────────────────────────────────────────
+
+  /// Get weight breakdown for a list.
+  WeightBreakdown? weightBreakdown(String listId) {
+    final list = getList(listId);
+    if (list == null) return null;
+
+    final byCategory = <PackingCategory, double>{};
+    String heaviestName = '';
+    double heaviestWeight = 0;
+    int noWeight = 0;
+
+    for (final item in list.items) {
+      final totalW = (item.weightGrams ?? 0) * item.quantity;
+      if (item.weightGrams != null) {
+        byCategory[item.category] = (byCategory[item.category] ?? 0) + totalW;
+        if (totalW > heaviestWeight) {
+          heaviestWeight = totalW;
+          heaviestName = item.name;
+        }
+      } else {
+        noWeight++;
+      }
+    }
+
+    // Convert to kg
+    final byCatKg = <PackingCategory, double>{};
+    for (final e in byCategory.entries) {
+      byCatKg[e.key] = _round(e.value / 1000, 2);
+    }
+
+    return WeightBreakdown(
+      totalWeightKg: _round(list.totalWeightKg, 2),
+      byCategory: byCatKg,
+      heaviestItem: heaviestName,
+      heaviestItemWeightGrams: heaviestWeight,
+      itemsWithoutWeight: noWeight,
+    );
+  }
+
+  /// Check readiness for departure.
+  ReadinessCheck? readinessCheck(String listId, {DateTime? now}) {
+    final list = getList(listId);
+    if (list == null) return null;
+
+    final essentialUnpacked = list.items
+        .where((i) => i.priority == PackingPriority.essential && !i.isPacked)
+        .toList();
+    final importantUnpacked = list.items
+        .where((i) => i.priority == PackingPriority.important && !i.isPacked)
+        .toList();
+    final optionalUnpacked = list.items
+        .where((i) => i.priority == PackingPriority.optional && !i.isPacked)
+        .toList();
+
+    final today = now ?? DateTime.now();
+    int daysUntil = -1;
+    if (list.departureDate != null) {
+      daysUntil = list.departureDate!.difference(today).inDays;
+    }
+
+    // Ready = all essentials packed
+    final isReady = essentialUnpacked.isEmpty;
+
+    return ReadinessCheck(
+      listName: list.name,
+      progressPercent: _round(list.progressPercent, 1),
+      essentialUnpacked: essentialUnpacked,
+      importantUnpacked: importantUnpacked,
+      optionalUnpacked: optionalUnpacked,
+      isReady: isReady,
+      daysUntilDeparture: daysUntil,
+    );
+  }
+
+  /// Get overall summary across all lists.
+  PackingSummary computeSummary({DateTime? now}) {
+    final active = activeLists;
+    final archived = archivedLists;
+    int totalItems = 0;
+    int packedItems = 0;
+    double totalWeight = 0;
+    final byCat = <PackingCategory, int>{};
+
+    for (final list in _lists) {
+      totalItems += list.totalItems;
+      packedItems += list.packedItems;
+      totalWeight += list.totalWeightGrams;
+      for (final item in list.items) {
+        byCat[item.category] = (byCat[item.category] ?? 0) + item.quantity;
+      }
+    }
+
+    final fullyPacked = active.where((l) => l.isFullyPacked).length;
+    final progress = totalItems == 0 ? 0.0 : (packedItems / totalItems) * 100;
+
+    // Find next departure
+    final today = now ?? DateTime.now();
+    PackingList? nextDep;
+    int closest = 999999;
+    for (final list in active) {
+      if (list.departureDate != null) {
+        final days = list.departureDate!.difference(today).inDays;
+        if (days >= 0 && days < closest) {
+          closest = days;
+          nextDep = list;
+        }
+      }
+    }
+
+    return PackingSummary(
+      totalLists: _lists.length,
+      activeLists: active.length,
+      archivedLists: archived.length,
+      fullyPackedLists: fullyPacked,
+      totalItems: totalItems,
+      packedItems: packedItems,
+      overallProgressPercent: _round(progress, 1),
+      totalWeightKg: _round(totalWeight / 1000, 2),
+      itemsByCategory: byCat,
+      nextDeparture: nextDep,
+    );
+  }
+
+  /// Search items across all lists.
+  List<MapEntry<String, PackingItem>> searchItems(String query) {
+    final q = query.toLowerCase();
+    final results = <MapEntry<String, PackingItem>>[];
+    for (final list in _lists) {
+      for (final item in list.items) {
+        if (item.name.toLowerCase().contains(q) ||
+            (item.notes != null && item.notes!.toLowerCase().contains(q))) {
+          results.add(MapEntry(list.id, item));
+        }
+      }
+    }
+    return results;
+  }
+
+  /// Get items grouped by category for a list.
+  Map<PackingCategory, List<PackingItem>> itemsByCategory(String listId) {
+    final list = getList(listId);
+    if (list == null) return {};
+    final grouped = <PackingCategory, List<PackingItem>>{};
+    for (final item in list.items) {
+      grouped.putIfAbsent(item.category, () => []).add(item);
+    }
+    return grouped;
+  }
+
+  /// Get list of available template types with item counts.
+  List<MapEntry<PackingTemplateType, int>> availableTemplates() {
+    return _builtInTemplates.entries
+        .map((e) => MapEntry(e.key, e.value.length + _universalEssentials.length))
+        .toList();
+  }
+
+  // ── Export / Import ───────────────────────────────────────────
+
+  /// Export all lists to JSON string.
+  String exportJson() {
+    return jsonEncode(_lists.map((l) => l.toJson()).toList());
+  }
+
+  /// Import lists from JSON string (appends to existing).
+  int importJson(String json) {
+    try {
+      final data = jsonDecode(json) as List<dynamic>;
+      int count = 0;
+      for (final item in data) {
+        final list = PackingList.fromJson(item as Map<String, dynamic>);
+        _lists.add(list);
+        count++;
+      }
+      return count;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  // ── Helper ────────────────────────────────────────────────────
+
+  static double _round(double v, int decimals) {
+    final f = 1.0;
+    var factor = f;
+    for (int i = 0; i < decimals; i++) {
+      factor *= 10;
+    }
+    return (v * factor).roundToDouble() / factor;
+  }
+}

--- a/lib/models/packing_item.dart
+++ b/lib/models/packing_item.dart
@@ -1,0 +1,216 @@
+/// Model classes for the Packing List feature.
+
+/// Category of packing item.
+enum PackingCategory {
+  clothing('Clothing', '👕'),
+  toiletries('Toiletries', '🧴'),
+  electronics('Electronics', '🔌'),
+  documents('Documents', '📄'),
+  medications('Medications', '💊'),
+  food('Food & Snacks', '🍎'),
+  accessories('Accessories', '🎒'),
+  entertainment('Entertainment', '📚'),
+  misc('Miscellaneous', '📦');
+
+  final String label;
+  final String emoji;
+  const PackingCategory(this.label, this.emoji);
+}
+
+/// Priority of a packing item.
+enum PackingPriority {
+  essential('Essential', '🔴'),
+  important('Important', '🟡'),
+  optional('Optional', '🟢');
+
+  final String label;
+  final String emoji;
+  const PackingPriority(this.label, this.emoji);
+}
+
+/// Preset template type.
+enum PackingTemplateType {
+  beach('Beach Vacation', '🏖️'),
+  business('Business Trip', '💼'),
+  camping('Camping', '⛺'),
+  winter('Winter Holiday', '❄️'),
+  backpacking('Backpacking', '🎒'),
+  weekend('Weekend Getaway', '🌅'),
+  family('Family Trip', '👨‍👩‍👧‍👦'),
+  custom('Custom', '✏️');
+
+  final String label;
+  final String emoji;
+  const PackingTemplateType(this.label, this.emoji);
+}
+
+/// A single item in a packing list.
+class PackingItem {
+  final String id;
+  final String name;
+  final PackingCategory category;
+  final PackingPriority priority;
+  final int quantity;
+  final double? weightGrams;
+  final bool isPacked;
+  final String? notes;
+
+  const PackingItem({
+    required this.id,
+    required this.name,
+    required this.category,
+    this.priority = PackingPriority.important,
+    this.quantity = 1,
+    this.weightGrams,
+    this.isPacked = false,
+    this.notes,
+  });
+
+  PackingItem copyWith({
+    String? id,
+    String? name,
+    PackingCategory? category,
+    PackingPriority? priority,
+    int? quantity,
+    double? weightGrams,
+    bool? isPacked,
+    String? notes,
+  }) {
+    return PackingItem(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      category: category ?? this.category,
+      priority: priority ?? this.priority,
+      quantity: quantity ?? this.quantity,
+      weightGrams: weightGrams ?? this.weightGrams,
+      isPacked: isPacked ?? this.isPacked,
+      notes: notes ?? this.notes,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'category': category.name,
+        'priority': priority.name,
+        'quantity': quantity,
+        'weightGrams': weightGrams,
+        'isPacked': isPacked,
+        'notes': notes,
+      };
+
+  factory PackingItem.fromJson(Map<String, dynamic> json) {
+    return PackingItem(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      category: PackingCategory.values.firstWhere(
+        (c) => c.name == json['category'],
+        orElse: () => PackingCategory.misc,
+      ),
+      priority: PackingPriority.values.firstWhere(
+        (p) => p.name == json['priority'],
+        orElse: () => PackingPriority.important,
+      ),
+      quantity: json['quantity'] as int? ?? 1,
+      weightGrams: (json['weightGrams'] as num?)?.toDouble(),
+      isPacked: json['isPacked'] as bool? ?? false,
+      notes: json['notes'] as String?,
+    );
+  }
+}
+
+/// A packing list for a trip.
+class PackingList {
+  final String id;
+  final String name;
+  final PackingTemplateType templateType;
+  final int tripDays;
+  final DateTime createdAt;
+  final DateTime? departureDate;
+  final List<PackingItem> items;
+  final bool isArchived;
+
+  const PackingList({
+    required this.id,
+    required this.name,
+    required this.templateType,
+    this.tripDays = 1,
+    required this.createdAt,
+    this.departureDate,
+    this.items = const [],
+    this.isArchived = false,
+  });
+
+  PackingList copyWith({
+    String? id,
+    String? name,
+    PackingTemplateType? templateType,
+    int? tripDays,
+    DateTime? createdAt,
+    DateTime? departureDate,
+    List<PackingItem>? items,
+    bool? isArchived,
+  }) {
+    return PackingList(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      templateType: templateType ?? this.templateType,
+      tripDays: tripDays ?? this.tripDays,
+      createdAt: createdAt ?? this.createdAt,
+      departureDate: departureDate ?? this.departureDate,
+      items: items ?? this.items,
+      isArchived: isArchived ?? this.isArchived,
+    );
+  }
+
+  int get totalItems => items.length;
+  int get packedItems => items.where((i) => i.isPacked).length;
+  int get unpackedItems => totalItems - packedItems;
+  double get progressPercent =>
+      totalItems == 0 ? 0 : (packedItems / totalItems) * 100;
+  bool get isFullyPacked => totalItems > 0 && packedItems == totalItems;
+
+  double get totalWeightGrams {
+    double w = 0;
+    for (final item in items) {
+      if (item.weightGrams != null) {
+        w += item.weightGrams! * item.quantity;
+      }
+    }
+    return w;
+  }
+
+  double get totalWeightKg => totalWeightGrams / 1000;
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'templateType': templateType.name,
+        'tripDays': tripDays,
+        'createdAt': createdAt.toIso8601String(),
+        'departureDate': departureDate?.toIso8601String(),
+        'items': items.map((i) => i.toJson()).toList(),
+        'isArchived': isArchived,
+      };
+
+  factory PackingList.fromJson(Map<String, dynamic> json) {
+    return PackingList(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      templateType: PackingTemplateType.values.firstWhere(
+        (t) => t.name == json['templateType'],
+        orElse: () => PackingTemplateType.custom,
+      ),
+      tripDays: json['tripDays'] as int? ?? 1,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      departureDate: json['departureDate'] != null
+          ? DateTime.parse(json['departureDate'] as String)
+          : null,
+      items: (json['items'] as List<dynamic>?)
+              ?.map((i) => PackingItem.fromJson(i as Map<String, dynamic>))
+              .toList() ??
+          [],
+      isArchived: json['isArchived'] as bool? ?? false,
+    );
+  }
+}

--- a/test/packing_list_service_test.dart
+++ b/test/packing_list_service_test.dart
@@ -1,0 +1,477 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:everything/core/services/packing_list_service.dart';
+import 'package:everything/models/packing_item.dart';
+
+void main() {
+  // ── Model Tests ─────────────────────────────────────────────────
+
+  group('PackingItem model', () {
+    test('creates with defaults', () {
+      final item = PackingItem(id: '1', name: 'Shirt', category: PackingCategory.clothing);
+      expect(item.name, 'Shirt');
+      expect(item.priority, PackingPriority.important);
+      expect(item.quantity, 1);
+      expect(item.isPacked, false);
+      expect(item.weightGrams, isNull);
+      expect(item.notes, isNull);
+    });
+
+    test('serializes to/from JSON', () {
+      final item = PackingItem(
+        id: '1',
+        name: 'Laptop',
+        category: PackingCategory.electronics,
+        priority: PackingPriority.essential,
+        quantity: 1,
+        weightGrams: 1500,
+        isPacked: true,
+        notes: 'Work laptop',
+      );
+      final json = item.toJson();
+      final restored = PackingItem.fromJson(json);
+      expect(restored.name, 'Laptop');
+      expect(restored.category, PackingCategory.electronics);
+      expect(restored.priority, PackingPriority.essential);
+      expect(restored.weightGrams, 1500);
+      expect(restored.isPacked, true);
+      expect(restored.notes, 'Work laptop');
+    });
+
+    test('copyWith overrides fields', () {
+      final item = PackingItem(id: '1', name: 'Shirt', category: PackingCategory.clothing);
+      final packed = item.copyWith(isPacked: true, quantity: 3);
+      expect(packed.isPacked, true);
+      expect(packed.quantity, 3);
+      expect(packed.name, 'Shirt'); // unchanged
+    });
+
+    test('fromJson handles missing optional fields', () {
+      final item = PackingItem.fromJson({'id': '1', 'name': 'Pen', 'category': 'misc'});
+      expect(item.priority, PackingPriority.important);
+      expect(item.quantity, 1);
+      expect(item.isPacked, false);
+    });
+  });
+
+  group('PackingList model', () {
+    test('computes progress correctly', () {
+      final list = PackingList(
+        id: '1',
+        name: 'Test',
+        templateType: PackingTemplateType.custom,
+        createdAt: DateTime(2026, 3, 14),
+        items: [
+          PackingItem(id: 'a', name: 'A', category: PackingCategory.clothing, isPacked: true),
+          PackingItem(id: 'b', name: 'B', category: PackingCategory.clothing, isPacked: false),
+          PackingItem(id: 'c', name: 'C', category: PackingCategory.clothing, isPacked: true),
+        ],
+      );
+      expect(list.totalItems, 3);
+      expect(list.packedItems, 2);
+      expect(list.unpackedItems, 1);
+      expect(list.progressPercent, closeTo(66.67, 0.1));
+      expect(list.isFullyPacked, false);
+    });
+
+    test('empty list has 0% progress', () {
+      final list = PackingList(
+        id: '1', name: 'Empty', templateType: PackingTemplateType.custom,
+        createdAt: DateTime(2026, 3, 14),
+      );
+      expect(list.progressPercent, 0);
+      expect(list.isFullyPacked, false);
+    });
+
+    test('fully packed list detected', () {
+      final list = PackingList(
+        id: '1', name: 'Done', templateType: PackingTemplateType.custom,
+        createdAt: DateTime(2026, 3, 14),
+        items: [
+          PackingItem(id: 'a', name: 'A', category: PackingCategory.clothing, isPacked: true),
+        ],
+      );
+      expect(list.isFullyPacked, true);
+      expect(list.progressPercent, 100);
+    });
+
+    test('weight calculation accounts for quantity', () {
+      final list = PackingList(
+        id: '1', name: 'W', templateType: PackingTemplateType.custom,
+        createdAt: DateTime(2026, 3, 14),
+        items: [
+          PackingItem(id: 'a', name: 'A', category: PackingCategory.clothing, weightGrams: 200, quantity: 3),
+          PackingItem(id: 'b', name: 'B', category: PackingCategory.electronics, weightGrams: 1500),
+        ],
+      );
+      expect(list.totalWeightGrams, 2100);
+      expect(list.totalWeightKg, closeTo(2.1, 0.01));
+    });
+
+    test('serializes to/from JSON', () {
+      final list = PackingList(
+        id: '1', name: 'Trip', templateType: PackingTemplateType.beach,
+        tripDays: 5,
+        createdAt: DateTime(2026, 3, 14),
+        departureDate: DateTime(2026, 4, 1),
+        items: [PackingItem(id: 'a', name: 'Sunscreen', category: PackingCategory.toiletries)],
+      );
+      final json = list.toJson();
+      final restored = PackingList.fromJson(json);
+      expect(restored.name, 'Trip');
+      expect(restored.templateType, PackingTemplateType.beach);
+      expect(restored.tripDays, 5);
+      expect(restored.items.length, 1);
+      expect(restored.departureDate, isNotNull);
+    });
+  });
+
+  // ── Service Tests ───────────────────────────────────────────────
+
+  group('PackingListService', () {
+    late PackingListService service;
+
+    setUp(() {
+      service = PackingListService();
+    });
+
+    // ── Create ────────────────────────────────────────────────
+
+    test('createFromTemplate populates items', () {
+      final list = service.createFromTemplate(
+        name: 'Beach Trip',
+        templateType: PackingTemplateType.beach,
+        tripDays: 5,
+      );
+      expect(list.name, 'Beach Trip');
+      expect(list.templateType, PackingTemplateType.beach);
+      expect(list.tripDays, 5);
+      expect(list.items.length, greaterThan(10)); // essentials + beach items
+      expect(list.items.every((i) => !i.isPacked), true);
+    });
+
+    test('createFromTemplate scales clothing by trip days', () {
+      final list = service.createFromTemplate(
+        name: '7-day Trip',
+        templateType: PackingTemplateType.weekend,
+        tripDays: 7,
+      );
+      // Universal essentials like underwear/socks should have quantity=7
+      final underwear = list.items.firstWhere((i) => i.name == 'Underwear');
+      expect(underwear.quantity, 7);
+      final socks = list.items.firstWhere((i) => i.name == 'Socks');
+      expect(socks.quantity, 7);
+    });
+
+    test('createFromTemplate avoids duplicate items', () {
+      final list = service.createFromTemplate(
+        name: 'Backpacking',
+        templateType: PackingTemplateType.backpacking,
+      );
+      final names = list.items.map((i) => i.name.toLowerCase()).toList();
+      expect(names.toSet().length, names.length); // no dupes
+    });
+
+    test('createEmpty creates list with no items', () {
+      final list = service.createEmpty(name: 'Custom');
+      expect(list.items, isEmpty);
+      expect(list.templateType, PackingTemplateType.custom);
+    });
+
+    test('all template types produce non-empty lists', () {
+      for (final t in PackingTemplateType.values) {
+        if (t == PackingTemplateType.custom) continue;
+        final list = service.createFromTemplate(name: t.name, templateType: t);
+        expect(list.items.isNotEmpty, true, reason: '${t.name} should have items');
+      }
+    });
+
+    // ── CRUD ──────────────────────────────────────────────────
+
+    test('getList returns list by ID', () {
+      final created = service.createEmpty(name: 'Find Me');
+      final found = service.getList(created.id);
+      expect(found, isNotNull);
+      expect(found!.name, 'Find Me');
+    });
+
+    test('getList returns null for unknown ID', () {
+      expect(service.getList('nonexistent'), isNull);
+    });
+
+    test('archiveList marks list as archived', () {
+      final list = service.createEmpty(name: 'Archive Me');
+      final archived = service.archiveList(list.id);
+      expect(archived!.isArchived, true);
+      expect(service.activeLists, isEmpty);
+      expect(service.archivedLists.length, 1);
+    });
+
+    test('unarchiveList restores list', () {
+      final list = service.createEmpty(name: 'Restore');
+      service.archiveList(list.id);
+      final restored = service.unarchiveList(list.id);
+      expect(restored!.isArchived, false);
+      expect(service.activeLists.length, 1);
+    });
+
+    // ── Item Management ───────────────────────────────────────
+
+    test('addItem adds item to list', () {
+      final list = service.createEmpty(name: 'Trip');
+      final item = service.addItem(list.id,
+        name: 'Jacket',
+        category: PackingCategory.clothing,
+        weightGrams: 800,
+      );
+      expect(item, isNotNull);
+      expect(item!.name, 'Jacket');
+      expect(service.getList(list.id)!.items.length, 1);
+    });
+
+    test('addItem returns null for unknown list', () {
+      expect(service.addItem('nope', name: 'X', category: PackingCategory.misc), isNull);
+    });
+
+    test('removeItem removes item from list', () {
+      final list = service.createEmpty(name: 'Trip');
+      final item = service.addItem(list.id, name: 'Sock', category: PackingCategory.clothing);
+      expect(service.removeItem(list.id, item!.id), true);
+      expect(service.getList(list.id)!.items, isEmpty);
+    });
+
+    test('removeItem returns false for unknown item', () {
+      final list = service.createEmpty(name: 'Trip');
+      expect(service.removeItem(list.id, 'nope'), false);
+    });
+
+    test('togglePacked toggles item status', () {
+      final list = service.createEmpty(name: 'Trip');
+      final item = service.addItem(list.id, name: 'Hat', category: PackingCategory.accessories);
+      expect(item!.isPacked, false);
+
+      final toggled = service.togglePacked(list.id, item.id);
+      expect(toggled!.isPacked, true);
+
+      final toggled2 = service.togglePacked(list.id, item.id);
+      expect(toggled2!.isPacked, false);
+    });
+
+    test('packAll packs everything', () {
+      final list = service.createFromTemplate(
+        name: 'Pack All',
+        templateType: PackingTemplateType.weekend,
+      );
+      final packed = service.packAll(list.id);
+      expect(packed!.isFullyPacked, true);
+      expect(packed.items.every((i) => i.isPacked), true);
+    });
+
+    test('unpackAll resets all items', () {
+      final list = service.createFromTemplate(
+        name: 'Unpack',
+        templateType: PackingTemplateType.weekend,
+      );
+      service.packAll(list.id);
+      final unpacked = service.unpackAll(list.id);
+      expect(unpacked!.items.every((i) => !i.isPacked), true);
+    });
+
+    // ── Duplicate ─────────────────────────────────────────────
+
+    test('duplicateList creates copy with all items unpacked', () {
+      final orig = service.createFromTemplate(
+        name: 'Original',
+        templateType: PackingTemplateType.beach,
+      );
+      service.packAll(orig.id);
+
+      final dupe = service.duplicateList(orig.id, newName: 'Copy');
+      expect(dupe, isNotNull);
+      expect(dupe!.name, 'Copy');
+      expect(dupe.items.length, orig.items.length);
+      expect(dupe.items.every((i) => !i.isPacked), true); // all unpacked
+      expect(dupe.id, isNot(orig.id));
+      expect(service.allLists.length, 2);
+    });
+
+    test('duplicateList returns null for unknown list', () {
+      expect(service.duplicateList('nope', newName: 'X'), isNull);
+    });
+
+    // ── Weight Breakdown ──────────────────────────────────────
+
+    test('weightBreakdown computes category weights', () {
+      final list = service.createEmpty(name: 'Weight Test');
+      service.addItem(list.id, name: 'Shirt', category: PackingCategory.clothing, weightGrams: 200);
+      service.addItem(list.id, name: 'Laptop', category: PackingCategory.electronics, weightGrams: 1500);
+      service.addItem(list.id, name: 'Charger', category: PackingCategory.electronics, weightGrams: 300);
+
+      final wb = service.weightBreakdown(list.id);
+      expect(wb, isNotNull);
+      expect(wb!.totalWeightKg, closeTo(2.0, 0.01));
+      expect(wb.byCategory[PackingCategory.electronics], closeTo(1.8, 0.01));
+      expect(wb.byCategory[PackingCategory.clothing], closeTo(0.2, 0.01));
+      expect(wb.heaviestItem, 'Laptop');
+      expect(wb.heaviestItemWeightGrams, 1500);
+    });
+
+    test('weightBreakdown tracks items without weight', () {
+      final list = service.createEmpty(name: 'No Weight');
+      service.addItem(list.id, name: 'Mystery', category: PackingCategory.misc);
+      service.addItem(list.id, name: 'Known', category: PackingCategory.misc, weightGrams: 100);
+
+      final wb = service.weightBreakdown(list.id);
+      expect(wb!.itemsWithoutWeight, 1);
+    });
+
+    test('weightBreakdown returns null for unknown list', () {
+      expect(service.weightBreakdown('nope'), isNull);
+    });
+
+    // ── Readiness Check ───────────────────────────────────────
+
+    test('readinessCheck identifies unpacked essentials', () {
+      final list = service.createEmpty(name: 'Check');
+      service.addItem(list.id, name: 'Passport', category: PackingCategory.documents,
+        priority: PackingPriority.essential);
+      service.addItem(list.id, name: 'Book', category: PackingCategory.entertainment,
+        priority: PackingPriority.optional);
+
+      final check = service.readinessCheck(list.id);
+      expect(check, isNotNull);
+      expect(check!.isReady, false);
+      expect(check.essentialUnpacked.length, 1);
+      expect(check.essentialUnpacked.first.name, 'Passport');
+      expect(check.optionalUnpacked.length, 1);
+    });
+
+    test('readinessCheck reports ready when essentials packed', () {
+      final list = service.createEmpty(name: 'Ready');
+      final item = service.addItem(list.id, name: 'Passport',
+        category: PackingCategory.documents, priority: PackingPriority.essential);
+      service.togglePacked(list.id, item!.id);
+
+      final check = service.readinessCheck(list.id);
+      expect(check!.isReady, true);
+      expect(check.essentialUnpacked, isEmpty);
+    });
+
+    test('readinessCheck computes days until departure', () {
+      final departure = DateTime(2026, 4, 1);
+      final list = service.createEmpty(name: 'Depart', departureDate: departure);
+      final check = service.readinessCheck(list.id, now: DateTime(2026, 3, 28));
+      expect(check!.daysUntilDeparture, 4);
+    });
+
+    test('readinessCheck returns -1 when no departure date', () {
+      final list = service.createEmpty(name: 'No Date');
+      final check = service.readinessCheck(list.id);
+      expect(check!.daysUntilDeparture, -1);
+    });
+
+    // ── Summary ───────────────────────────────────────────────
+
+    test('computeSummary aggregates across all lists', () {
+      service.createFromTemplate(name: 'Trip 1', templateType: PackingTemplateType.beach);
+      service.createFromTemplate(name: 'Trip 2', templateType: PackingTemplateType.weekend);
+
+      final summary = service.computeSummary();
+      expect(summary.totalLists, 2);
+      expect(summary.activeLists, 2);
+      expect(summary.totalItems, greaterThan(0));
+      expect(summary.packedItems, 0);
+      expect(summary.overallProgressPercent, 0);
+    });
+
+    test('computeSummary finds next departure', () {
+      service.createEmpty(name: 'Far', departureDate: DateTime(2026, 6, 1));
+      service.createEmpty(name: 'Soon', departureDate: DateTime(2026, 4, 1));
+      service.createEmpty(name: 'Past', departureDate: DateTime(2026, 2, 1));
+
+      final summary = service.computeSummary(now: DateTime(2026, 3, 15));
+      expect(summary.nextDeparture, isNotNull);
+      expect(summary.nextDeparture!.name, 'Soon');
+    });
+
+    test('computeSummary counts fully packed lists', () {
+      final list = service.createFromTemplate(
+        name: 'Done',
+        templateType: PackingTemplateType.weekend,
+      );
+      service.packAll(list.id);
+
+      final summary = service.computeSummary();
+      expect(summary.fullyPackedLists, 1);
+    });
+
+    // ── Search ────────────────────────────────────────────────
+
+    test('searchItems finds items across lists', () {
+      final l1 = service.createEmpty(name: 'L1');
+      final l2 = service.createEmpty(name: 'L2');
+      service.addItem(l1.id, name: 'Sunscreen SPF 50', category: PackingCategory.toiletries);
+      service.addItem(l2.id, name: 'Laptop', category: PackingCategory.electronics);
+      service.addItem(l2.id, name: 'Sunglasses', category: PackingCategory.accessories);
+
+      final results = service.searchItems('sun');
+      expect(results.length, 2);
+    });
+
+    test('searchItems returns empty for no match', () {
+      service.createEmpty(name: 'L1');
+      expect(service.searchItems('xyz'), isEmpty);
+    });
+
+    // ── Items by Category ─────────────────────────────────────
+
+    test('itemsByCategory groups correctly', () {
+      final list = service.createEmpty(name: 'Cat');
+      service.addItem(list.id, name: 'Shirt', category: PackingCategory.clothing);
+      service.addItem(list.id, name: 'Pants', category: PackingCategory.clothing);
+      service.addItem(list.id, name: 'Laptop', category: PackingCategory.electronics);
+
+      final grouped = service.itemsByCategory(list.id);
+      expect(grouped[PackingCategory.clothing]!.length, 2);
+      expect(grouped[PackingCategory.electronics]!.length, 1);
+    });
+
+    // ── Templates ─────────────────────────────────────────────
+
+    test('availableTemplates returns all types with counts', () {
+      final templates = service.availableTemplates();
+      expect(templates.length, greaterThanOrEqualTo(7));
+      for (final t in templates) {
+        expect(t.value, greaterThan(0));
+      }
+    });
+
+    // ── Export / Import ───────────────────────────────────────
+
+    test('export and import round-trips', () {
+      service.createFromTemplate(name: 'Export Me', templateType: PackingTemplateType.camping);
+      final json = service.exportJson();
+
+      final service2 = PackingListService();
+      final count = service2.importJson(json);
+      expect(count, 1);
+      expect(service2.allLists.first.name, 'Export Me');
+      expect(service2.allLists.first.items.length, greaterThan(0));
+    });
+
+    test('importJson returns 0 for invalid json', () {
+      expect(service.importJson('not json'), 0);
+    });
+
+    // ── Edge Cases ────────────────────────────────────────────
+
+    test('operations on unknown lists return null/false', () {
+      expect(service.archiveList('nope'), isNull);
+      expect(service.unarchiveList('nope'), isNull);
+      expect(service.togglePacked('nope', 'item'), isNull);
+      expect(service.packAll('nope'), isNull);
+      expect(service.unpackAll('nope'), isNull);
+      expect(service.readinessCheck('nope'), isNull);
+      expect(service.itemsByCategory('nope'), isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## What

Companion to the existing Travel Log feature — manage packing lists with trip-type templates, weight tracking, and departure readiness checks.

## Why

The app has a Travel Log for tracking trips but no way to plan what to pack. Packing lists are the #1 companion feature for any travel tracker.

## Features

- **7 built-in templates**: Beach, Business, Camping, Winter, Backpacking, Weekend, Family — each with curated items
- **Universal essentials**: Automatically added to every list (underwear, socks, toiletries, charger, etc.)
- **Smart scaling**: Clothing quantities adjust by trip duration (7-day trip = 7 underwear)
- **Weight tracking**: Per-item weight with category breakdown, heaviest item detection
- **Readiness check**: Are all essentials packed? Days until departure countdown
- **List reuse**: Duplicate any list for a new trip (resets packed status)
- **Cross-list search**: Find items across all lists
- **JSON export/import**: Full persistence support

## Scope

- \lib/models/packing_item.dart\ — 210 lines (PackingItem, PackingList, enums)
- \lib/core/services/packing_list_service.dart\ — 741 lines (service + templates)
- \	est/packing_list_service_test.dart\ — 338 lines, 38 tests