### PR TITLE
fix: List.removeWhere() returns void — 5 methods had wrong return values

### DIFF
--- a/lib/core/services/grocery_list_service.dart
+++ b/lib/core/services/grocery_list_service.dart
@@ -77,7 +77,9 @@ class GroceryListService {
 
   /// Delete a list.
   bool deleteList(String listId) {
-    return _lists.removeWhere((l) => l.id == listId) != null || true;
+    final before = _lists.length;
+    _lists.removeWhere((l) => l.id == listId);
+    return _lists.length < before;
   }
 
   /// Add an item to a list.
@@ -168,9 +170,10 @@ class GroceryListService {
     if (listIndex < 0) return false;
 
     final items = List<GroceryItem>.from(_lists[listIndex].items);
-    final removed = items.removeWhere((i) => i.id == itemId);
+    final before = items.length;
+    items.removeWhere((i) => i.id == itemId);
     _lists[listIndex] = _lists[listIndex].copyWith(items: items);
-    return true;
+    return items.length < before;
   }
 
   /// Remove all checked items from a list.

--- a/lib/core/services/net_worth_tracker_service.dart
+++ b/lib/core/services/net_worth_tracker_service.dart
@@ -205,7 +205,9 @@ class NetWorthTrackerService {
 
   /// Permanently remove an account.
   bool removeAccount(String accountId) {
-    return _accounts.removeWhere((a) => a.id == accountId) != null;
+    final before = _accounts.length;
+    _accounts.removeWhere((a) => a.id == accountId);
+    return _accounts.length < before;
   }
 
   /// Find account by ID.

--- a/lib/core/services/plant_care_service.dart
+++ b/lib/core/services/plant_care_service.dart
@@ -139,9 +139,10 @@ class PlantCareService {
   }
 
   bool removePlant(String id) {
-    final removed = _plants.removeWhere((p) => p.id == id);
+    final before = _plants.length;
+    _plants.removeWhere((p) => p.id == id);
     _careLog.removeWhere((e) => e.plantId == id);
-    return true;
+    return _plants.length < before;
   }
 
   // ─── Care Logging ───

--- a/lib/core/services/savings_goal_service.dart
+++ b/lib/core/services/savings_goal_service.dart
@@ -77,7 +77,9 @@ class SavingsGoalService {
 
   /// Remove a goal entirely.
   bool removeGoal(String goalId) {
-    return _goals.removeWhere((g) => g.id == goalId) != null;
+    final before = _goals.length;
+    _goals.removeWhere((g) => g.id == goalId);
+    return _goals.length < before;
   }
 
   /// Archive/unarchive a goal.


### PR DESCRIPTION
Fixes 5 methods across 4 services that incorrectly use List.removeWhere() return value. In Dart, removeWhere() returns void, not the removed element. Comparing void != null always evaluates to false. Fix: compare list length before/after removeWhere().