### PR TITLE
fix: milestone progress not synced after toggle/remove in GoalTracker

### DIFF
--- a/lib/core/services/goal_tracker_service.dart
+++ b/lib/core/services/goal_tracker_service.dart
@@ -95,10 +95,20 @@ class GoalTrackerService {
 
     // Auto-complete goal if all milestones done.
     final allDone = milestones.every((m) => m.isCompleted);
+
+    // Compute progress from milestones so it stays in sync.
+    // Previously, untoggling a milestone after auto-complete kept
+    // progress at 100 because the old value was carried forward.
+    final completedCount =
+        milestones.where((m) => m.isCompleted).length;
+    final milestoneProgress = milestones.isEmpty
+        ? goal.progress
+        : (completedCount / milestones.length * 100).round();
+
     _goals[idx] = goal.copyWith(
       milestones: milestones,
       isCompleted: allDone,
-      progress: allDone ? 100 : goal.progress,
+      progress: milestoneProgress,
     );
   }
 
@@ -117,7 +127,21 @@ class GoalTrackerService {
         .milestones
         .where((m) => m.id != milestoneId)
         .toList();
-    _goals[idx] = _goals[idx].copyWith(milestones: milestones);
+
+    // Recalculate progress after removing a milestone.
+    final allDone = milestones.isNotEmpty &&
+        milestones.every((m) => m.isCompleted);
+    final completedCount =
+        milestones.where((m) => m.isCompleted).length;
+    final newProgress = milestones.isEmpty
+        ? _goals[idx].progress
+        : (completedCount / milestones.length * 100).round();
+
+    _goals[idx] = _goals[idx].copyWith(
+      milestones: milestones,
+      progress: newProgress,
+      isCompleted: allDone,
+    );
   }
 
   // ── Progress ──────────────────────────────────────────────────────

--- a/test/goal_tracker_service_test.dart
+++ b/test/goal_tracker_service_test.dart
@@ -180,6 +180,39 @@ void main() {
       expect(goal.isCompleted, true);
       expect(goal.progress, 100);
     });
+
+    test('toggling one milestone shows 50% progress', () {
+      service.toggleMilestone('g1', 'm1');
+      final goal = service.allGoals.first;
+      expect(goal.progress, 50);
+      expect(goal.isCompleted, false);
+    });
+
+    test('uncompleting milestone after auto-complete reduces progress', () {
+      // Complete all → auto-complete at 100%
+      service.toggleMilestone('g1', 'm1');
+      service.toggleMilestone('g1', 'm2');
+      expect(service.allGoals.first.progress, 100);
+      expect(service.allGoals.first.isCompleted, true);
+
+      // Untoggle one → should drop to 50%, not stay at 100%
+      service.toggleMilestone('g1', 'm2');
+      final goal = service.allGoals.first;
+      expect(goal.progress, 50);
+      expect(goal.isCompleted, false);
+    });
+
+    test('removeMilestone recalculates progress', () {
+      service.toggleMilestone('g1', 'm1');
+      // m1 completed, m2 pending → 50%
+      expect(service.allGoals.first.progress, 50);
+
+      // Remove the pending one → only completed m1 remains → 100%
+      service.removeMilestone('g1', 'm2');
+      final goal = service.allGoals.first;
+      expect(goal.progress, 100);
+      expect(goal.isCompleted, true);
+    });
   });
 
   group('GoalTrackerService progress', () {


### PR DESCRIPTION
## Bug

toggleMilestone had a state sync bug:
1. Complete all milestones -> progress=100, isCompleted=true
2. Uncomplete any milestone -> isCompleted=false but **progress stays 100**
3. Progress never reflected partial milestone completion (e.g. 1/2 = 50%)

removeMilestone had a similar issue: removing a milestone didn't recalculate progress or completion status.

## Fix

Both methods now compute progress from the milestone ratio:
- completedCount / totalMilestones * 100
- isCompleted tracks whether all milestones are done

## Tests
+3 tests covering the bug path, partial progress, and remove-recalculation.