### PR TITLE
perf: add batch insert for LocalStorage and EventRepository

### DIFF
--- a/lib/data/local_storage.dart
+++ b/lib/data/local_storage.dart
@@ -188,6 +188,26 @@ class LocalStorage {
     );
   }
 
+  /// Inserts or replaces multiple rows in [table] within a single transaction.
+  ///
+  /// This is significantly faster than calling [insert] in a loop because
+  /// SQLite commits each standalone insert as its own transaction (fsync),
+  /// whereas batching them amortizes the cost to a single fsync.
+  /// Throws [ArgumentError] if [table] is not a recognized table name.
+  static Future<void> insertAll(
+      String table, List<Map<String, dynamic>> rows) async {
+    if (rows.isEmpty) return;
+    _validateTable(table);
+    final db = await database;
+    await db.transaction((txn) async {
+      final batch = txn.batch();
+      for (final row in rows) {
+        batch.insert(table, row, conflictAlgorithm: ConflictAlgorithm.replace);
+      }
+      await batch.commit(noResult: true);
+    });
+  }
+
   /// Closes the database connection and clears the cached instance.
   ///
   /// After calling this, the next access to [database] will re-open

--- a/lib/data/repositories/event_repository.dart
+++ b/lib/data/repositories/event_repository.dart
@@ -71,4 +71,13 @@ class EventRepository {
   Future<void> updateEvent(Map<String, dynamic> event) async {
     await LocalStorage.insert('events', event);
   }
+
+  /// Saves multiple events in a single transaction.
+  ///
+  /// Uses [LocalStorage.insertAll] to batch all inserts into one
+  /// transaction, which is dramatically faster than individual inserts
+  /// when persisting many events (e.g. initial sync or import).
+  Future<void> saveAllEvents(List<Map<String, dynamic>> events) async {
+    await LocalStorage.insertAll('events', events);
+  }
 }


### PR DESCRIPTION
Add insertAll() to LocalStorage for batched transaction inserts and saveAllEvents() to EventRepository. Single transaction with N inserts is ~50-100x faster than N individual transactions due to amortized fsync overhead.