### PR TITLE
security: add maxImportEntries guards to 13 unprotected import methods

### DIFF
--- a/lib/core/services/budget_planner_service.dart
+++ b/lib/core/services/budget_planner_service.dart
@@ -342,8 +342,18 @@ class BudgetPlannerService {
       _budgets.map((b) => b.toJson()).toList());
 
   /// Import budgets from a JSON string, replacing current state.
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String json) {
     final data = jsonDecode(json) as List<dynamic>;
+    if (data.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${data.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     _budgets.clear();
     _budgets.addAll(
         data.map((b) => MonthlyBudget.fromJson(b as Map<String, dynamic>)));

--- a/lib/core/services/coupon_tracker_service.dart
+++ b/lib/core/services/coupon_tracker_service.dart
@@ -223,8 +223,18 @@ class CouponTrackerService {
   String exportToJson() =>
       jsonEncode(_coupons.map((c) => c.toJson()).toList());
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String jsonStr) {
     final list = jsonDecode(jsonStr) as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     _coupons.clear();
     for (final item in list) {
       _coupons.add(CouponEntry.fromJson(item as Map<String, dynamic>));

--- a/lib/core/services/debt_payoff_service.dart
+++ b/lib/core/services/debt_payoff_service.dart
@@ -267,8 +267,18 @@ class DebtPayoffService {
         _debts.map((d) => d.toJson()).toList(),
       );
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String json) {
     final list = jsonDecode(json) as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     _debts
       ..clear()
       ..addAll(list.map(

--- a/lib/core/services/document_expiry_service.dart
+++ b/lib/core/services/document_expiry_service.dart
@@ -102,9 +102,19 @@ class DocumentExpiryService {
 
   String exportToJson() => jsonEncode(_documents.map((d) => d.toJson()).toList());
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String json) {
-    _documents.clear();
     final list = jsonDecode(json) as List;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
+    _documents.clear();
     _documents.addAll(list.map((e) => DocumentEntry.fromJson(e as Map<String, dynamic>)));
   }
 }

--- a/lib/core/services/grocery_list_service.dart
+++ b/lib/core/services/grocery_list_service.dart
@@ -306,9 +306,19 @@ class GroceryListService {
   }
 
   /// Import lists from JSON.
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   int importFromJson(String json) {
     try {
       final decoded = jsonDecode(json) as List<dynamic>;
+      if (decoded.length > maxImportEntries) {
+        throw ArgumentError(
+          'Import exceeds maximum of $maxImportEntries entries '
+          '(got ${decoded.length}). This limit prevents memory exhaustion '
+          'from corrupted or malicious data.',
+        );
+      }
       int count = 0;
       for (final item in decoded) {
         final list = GroceryList.fromJson(item as Map<String, dynamic>);
@@ -316,6 +326,8 @@ class GroceryListService {
         count++;
       }
       return count;
+    } on ArgumentError {
+      rethrow;
     } catch (_) {
       return 0;
     }

--- a/lib/core/services/home_inventory_service.dart
+++ b/lib/core/services/home_inventory_service.dart
@@ -192,8 +192,18 @@ class HomeInventoryService {
   }
 
   /// Import inventory from JSON string (appends).
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   int importFromJson(String jsonStr) {
     final list = jsonDecode(jsonStr) as List;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     int count = 0;
     for (final item in list) {
       _items.add(InventoryItem.fromJson(item as Map<String, dynamic>));

--- a/lib/core/services/home_maintenance_service.dart
+++ b/lib/core/services/home_maintenance_service.dart
@@ -156,9 +156,19 @@ class HomeMaintenanceService {
   String exportToJson() =>
       jsonEncode(_tasks.map((t) => t.toJson()).toList());
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String json) {
-    _tasks.clear();
     final list = jsonDecode(json) as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
+    _tasks.clear();
     _tasks.addAll(list.map((j) =>
         HomeMaintenanceEntry.fromJson(j as Map<String, dynamic>)));
   }

--- a/lib/core/services/loyalty_tracker_service.dart
+++ b/lib/core/services/loyalty_tracker_service.dart
@@ -323,8 +323,18 @@ class LoyaltyTrackerService {
       const JsonEncoder.withIndent('  ')
           .convert(_cards.map((c) => c.toJson()).toList());
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   int importFromJson(String jsonStr) {
     final list = jsonDecode(jsonStr) as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     int imported = 0;
     for (final item in list) {
       final card = LoyaltyCard.fromJson(item as Map<String, dynamic>);

--- a/lib/core/services/net_worth_tracker_service.dart
+++ b/lib/core/services/net_worth_tracker_service.dart
@@ -551,8 +551,18 @@ class NetWorthTrackerService {
   }
 
   /// Import accounts from JSON string.
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   int importFromJson(String jsonStr) {
     final List<dynamic> data = json.decode(jsonStr) as List<dynamic>;
+    if (data.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${data.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     int imported = 0;
     for (final item in data) {
       try {

--- a/lib/core/services/plant_care_service.dart
+++ b/lib/core/services/plant_care_service.dart
@@ -409,16 +409,36 @@ class PlantCareService {
         'nextId': _nextId,
       };
 
+  /// Maximum entries allowed via [loadFromJson] to prevent memory exhaustion.
+  static const int maxImportPlants = 50000;
+  static const int maxImportCareLog = 100000;
+
   void loadFromJson(Map<String, dynamic> json) {
     _plants.clear();
     _careLog.clear();
     if (json['plants'] != null) {
-      for (final p in json['plants'] as List) {
+      final plantList = json['plants'] as List;
+      if (plantList.length > maxImportPlants) {
+        throw ArgumentError(
+          'Import exceeds maximum of $maxImportPlants plants '
+          '(got ${plantList.length}). This limit prevents memory exhaustion '
+          'from corrupted or malicious data.',
+        );
+      }
+      for (final p in plantList) {
         _plants.add(PlantProfile.fromJson(p as Map<String, dynamic>));
       }
     }
     if (json['careLog'] != null) {
-      for (final e in json['careLog'] as List) {
+      final careList = json['careLog'] as List;
+      if (careList.length > maxImportCareLog) {
+        throw ArgumentError(
+          'Import exceeds maximum of $maxImportCareLog care log entries '
+          '(got ${careList.length}). This limit prevents memory exhaustion '
+          'from corrupted or malicious data.',
+        );
+      }
+      for (final e in careList) {
         _careLog.add(PlantCareEntry.fromJson(e as Map<String, dynamic>));
       }
     }

--- a/lib/core/services/routine_builder_service.dart
+++ b/lib/core/services/routine_builder_service.dart
@@ -489,10 +489,29 @@ class RoutineBuilderService {
       });
 
   /// Import routines and runs from a JSON string, replacing current state.
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportRoutines = 50000;
+  static const int maxImportRuns = 100000;
+
   void importFromJson(String json) {
     final data = jsonDecode(json) as Map<String, dynamic>;
     final rawRoutines = data['routines'] as List<dynamic>? ?? [];
     final rawRuns = data['runs'] as List<dynamic>? ?? [];
+
+    if (rawRoutines.length > maxImportRoutines) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportRoutines routines '
+        '(got ${rawRoutines.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
+    if (rawRuns.length > maxImportRuns) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportRuns runs '
+        '(got ${rawRuns.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
 
     final parsedRoutines = rawRoutines
         .map((r) => Routine.fromJson(r as Map<String, dynamic>))

--- a/lib/core/services/vehicle_maintenance_service.dart
+++ b/lib/core/services/vehicle_maintenance_service.dart
@@ -269,17 +269,35 @@ class VehicleMaintenanceService {
     });
   }
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportVehicles = 10000;
+  static const int maxImportRecords = 100000;
+
   void importFromJson(String jsonStr) {
     final data = jsonDecode(jsonStr) as Map<String, dynamic>;
-    _vehicles.clear();
-    _records.clear();
 
     final vehicleList = data['vehicles'] as List<dynamic>? ?? [];
+    if (vehicleList.length > maxImportVehicles) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportVehicles vehicles '
+        '(got ${vehicleList.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
+    final recordList = data['records'] as List<dynamic>? ?? [];
+    if (recordList.length > maxImportRecords) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportRecords records '
+        '(got ${recordList.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
+
+    _vehicles.clear();
+    _records.clear();
     for (final v in vehicleList) {
       _vehicles.add(Vehicle.fromJson(v as Map<String, dynamic>));
     }
-
-    final recordList = data['records'] as List<dynamic>? ?? [];
     for (final r in recordList) {
       _records.add(MaintenanceRecord.fromJson(r as Map<String, dynamic>));
     }

--- a/lib/core/services/warranty_tracker_service.dart
+++ b/lib/core/services/warranty_tracker_service.dart
@@ -233,8 +233,18 @@ class WarrantyTrackerService {
   String exportToJson() =>
       jsonEncode(_warranties.map((w) => w.toJson()).toList());
 
+  /// Maximum entries allowed via [importFromJson] to prevent memory exhaustion.
+  static const int maxImportEntries = 50000;
+
   void importFromJson(String jsonStr) {
     final list = jsonDecode(jsonStr) as List<dynamic>;
+    if (list.length > maxImportEntries) {
+      throw ArgumentError(
+        'Import exceeds maximum of $maxImportEntries entries '
+        '(got ${list.length}). This limit prevents memory exhaustion '
+        'from corrupted or malicious data.',
+      );
+    }
     _warranties.clear();
     for (final item in list) {
       _warranties.add(


### PR DESCRIPTION
## Summary

Several importFromJson/loadFromJson methods across 13 services lacked size limits, making them vulnerable to memory exhaustion from corrupted or malicious import data.

## Changes

Added maxImportEntries guards to: budget_planner, coupon_tracker, debt_payoff, document_expiry, grocery_list, home_inventory, home_maintenance, loyalty_tracker, net_worth_tracker, plant_care, routine_builder, vehicle_maintenance, warranty_tracker.

Follows the existing guard pattern from 11 already-protected services. All guards throw ArgumentError with descriptive messages.

## Impact

Prevents potential OOM from large/malicious JSON payloads during data import. No behavioral change for normal usage.