### PR TITLE
refactor: extract SnackBarHelper to unify snackbar usage

### DIFF
--- a/lib/core/utils/snackbar_helper.dart
+++ b/lib/core/utils/snackbar_helper.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+/// Centralised SnackBar helper to ensure consistent feedback across the app.
+///
+/// **Before (repeated in 50+ screens):**
+/// ```dart
+/// ScaffoldMessenger.of(context).showSnackBar(
+///   SnackBar(
+///     content: Text('Item saved!'),
+///     behavior: SnackBarBehavior.floating,
+///     duration: Duration(seconds: 2),
+///   ),
+/// );
+/// ```
+///
+/// **After:**
+/// ```dart
+/// SnackBarHelper.show(context, 'Item saved!');
+/// SnackBarHelper.success(context, 'Item saved!');
+/// SnackBarHelper.error(context, 'Something went wrong');
+/// ```
+class SnackBarHelper {
+  SnackBarHelper._();
+
+  static const _defaultDuration = Duration(seconds: 2);
+  static const _shortDuration = Duration(seconds: 1);
+
+  /// Show a standard informational snackbar.
+  static void show(
+    BuildContext context,
+    String message, {
+    Duration? duration,
+    SnackBarAction? action,
+  }) {
+    _display(context, message, duration: duration, action: action);
+  }
+
+  /// Show a success snackbar (green background).
+  static void success(
+    BuildContext context,
+    String message, {
+    Duration? duration,
+    SnackBarAction? action,
+  }) {
+    _display(
+      context,
+      message,
+      backgroundColor: Colors.green,
+      duration: duration,
+      action: action,
+    );
+  }
+
+  /// Show an error snackbar (red background).
+  static void error(
+    BuildContext context,
+    String message, {
+    Duration? duration,
+    SnackBarAction? action,
+  }) {
+    _display(
+      context,
+      message,
+      backgroundColor: Colors.red,
+      duration: duration,
+      action: action,
+    );
+  }
+
+  /// Show a brief confirmation (1 second, floating).
+  static void brief(BuildContext context, String message) {
+    _display(context, message, duration: _shortDuration);
+  }
+
+  static void _display(
+    BuildContext context,
+    String message, {
+    Color? backgroundColor,
+    Duration? duration,
+    SnackBarAction? action,
+  }) {
+    ScaffoldMessenger.of(context)
+      ..hideCurrentSnackBar()
+      ..showSnackBar(
+        SnackBar(
+          content: Text(message),
+          behavior: SnackBarBehavior.floating,
+          duration: duration ?? _defaultDuration,
+          backgroundColor: backgroundColor,
+          action: action,
+        ),
+      );
+  }
+}

--- a/lib/views/home/bookmark_screen.dart
+++ b/lib/views/home/bookmark_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../models/bookmark.dart';
 import '../../core/services/bookmark_service.dart';
 import '../../core/services/screen_persistence.dart';
+import '../../core/utils/snackbar_helper.dart';
 
 /// Bookmark Manager Screen — 4-tab UI for saving & organizing URLs.
 ///
@@ -129,9 +130,7 @@ class _BookmarkScreenState extends State<BookmarkScreen>
     _tagsController.clear();
     setState(() => _selectedFolder = BookmarkFolder.general);
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Bookmark saved ✓'), duration: Duration(seconds: 2)),
-    );
+    SnackBarHelper.success(context, 'Bookmark saved ✓');
   }
 
   void _deleteBookmark(String id) {
@@ -162,9 +161,7 @@ class _BookmarkScreenState extends State<BookmarkScreen>
     });
     _save();
     // URL opening would require url_launcher package
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Visiting ${bookmark.title}'), duration: const Duration(seconds: 1)),
-    );
+    SnackBarHelper.brief(context, 'Visiting ${bookmark.title}');
   }
 
   @override

--- a/lib/views/home/bucket_list_screen.dart
+++ b/lib/views/home/bucket_list_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../models/bucket_item.dart';
 import '../../core/services/bucket_list_service.dart';
 import '../../core/services/screen_persistence.dart';
+import '../../core/utils/snackbar_helper.dart';
 
 /// Bucket List screen — 4-tab UI for tracking life dreams and experiences.
 class BucketListScreen extends StatefulWidget {
@@ -140,9 +141,7 @@ class _AddTabState extends State<_AddTab> {
 
   void _submit() {
     if (_titleCtrl.text.trim().isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please enter a title')),
-      );
+      SnackBarHelper.error(context, 'Please enter a title');
       return;
     }
 
@@ -176,9 +175,7 @@ class _AddTabState extends State<_AddTab> {
       _targetDate = null;
     });
 
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Added "${item.title}" to bucket list! 🎯')),
-    );
+    SnackBarHelper.success(context, 'Added "${item.title}" to bucket list! 🎯');
   }
 
   @override
@@ -601,10 +598,7 @@ class _ListTab extends StatelessWidget {
                   rating: rating > 0 ? rating : null,
                 );
                 Navigator.pop(ctx);
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                      content: Text('Completed "${item.title}"! 🎉')),
-                );
+                SnackBarHelper.success(context, 'Completed "${item.title}"! 🎉');
               },
               child: const Text('Complete!'),
             ),

--- a/lib/views/home/chore_tracker_screen.dart
+++ b/lib/views/home/chore_tracker_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../core/services/chore_tracker_service.dart';
 import '../../core/services/screen_persistence.dart';
+import '../../core/utils/snackbar_helper.dart';
 import '../../models/chore_entry.dart';
 
 /// Chore Tracker screen — manage household chores, log completions,
@@ -100,13 +101,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
       ));
     });
     _saveAll();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: const Text('✅ Chore completed!'),
-        duration: const Duration(seconds: 1),
-        behavior: SnackBarBehavior.floating,
-      ),
-    );
+    SnackBarHelper.brief(context, '✅ Chore completed!');
   }
 
   @override
@@ -394,12 +389,7 @@ class _ChoreTrackerScreenState extends State<ChoreTrackerScreen>
       onAdd: (chore) {
         _addChore(chore);
         _tabController.animateTo(0);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('Added "${chore.name}"'),
-            behavior: SnackBarBehavior.floating,
-          ),
-        );
+        SnackBarHelper.show(context, 'Added "${chore.name}"');
       },
       nextId: _nextChoreId++,
     );
@@ -798,12 +788,7 @@ class _AddChoreFormState extends State<_AddChoreForm> {
           onPressed: () {
             final name = _nameCtrl.text.trim();
             if (name.isEmpty) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Please enter a chore name'),
-                  behavior: SnackBarBehavior.floating,
-                ),
-              );
+              SnackBarHelper.error(context, 'Please enter a chore name');
               return;
             }
             widget.onAdd(Chore(


### PR DESCRIPTION
## What

Add \lib/core/utils/snackbar_helper.dart\ — a centralised helper replacing raw \ScaffoldMessenger.of(context).showSnackBar\ calls with consistent, concise methods:

- \SnackBarHelper.show(context, msg)\ — standard info
- \SnackBarHelper.success(context, msg)\ — green background
- \SnackBarHelper.error(context, msg)\ — red background
- \SnackBarHelper.brief(context, msg)\ — 1-second confirmation

## Why

The app has ~185 raw SnackBar call sites with inconsistent behavior:
- Some use \SnackBarBehavior.floating\, some don't
- Duration varies from 1s to default 4s
- Some set backgroundColor, some don't
- No auto-dismiss of previous snackbar

The helper enforces:
- Always floating behavior
- Dismisses current snackbar before showing new one
- Consistent 2s default / 1s brief durations
- Semantic color coding (success=green, error=red)

## Scope

Migrated 3 screens as initial adopters:
- \ookmark_screen.dart\ (2 sites)
- \ucket_list_screen.dart\ (3 sites)
- \chore_tracker_screen.dart\ (3 sites)

Remaining screens can adopt incrementally.