### PR TITLE
perf: use O(1) version check instead of O(n) hashAll in filter bar cache

### DIFF
--- a/lib/views/home/home_screen.dart
+++ b/lib/views/home/home_screen.dart
@@ -420,10 +420,15 @@ class _HomeScreenState extends State<HomeScreen> {
 
   /// Recomputes priority counts and tag aggregations only when the
   /// underlying event list changes, avoiding O(n·t) work per build.
+  ///
+  /// Uses [EventProvider.version] for O(1) change detection instead of
+  /// [Object.hashAll] which was O(n) — computing the hash of the entire
+  /// event list on every widget rebuild, defeating the cache purpose.
   void _ensureFilterBarCache(List<EventModel> allEvents) {
-    final hash = Object.hashAll(allEvents);
-    if (hash == _cachedFilterBarHash) return;
-    _cachedFilterBarHash = hash;
+    final eventProvider = Provider.of<EventProvider>(context, listen: false);
+    final version = eventProvider.version;
+    if (version == _cachedFilterBarHash) return;
+    _cachedFilterBarHash = version;
 
     final priorityCounts = <EventPriority, int>{};
     final allTags = <String, EventTag>{};


### PR DESCRIPTION
## What

Replace \Object.hashAll(allEvents)\ with \EventProvider.version\ in \_ensureFilterBarCache()\.

## Why

The filter bar cache was using \Object.hashAll(allEvents)\ on every widget rebuild to detect if the event list changed. This is O(n) — it hashes every event object in the list — which defeats the purpose of caching and gets worse as the list grows.

\EventProvider\ already has a \ersion\ counter that increments on every mutation (add/remove/update/set/clear). \_getFilteredEvents()\ already uses it for O(1) change detection. The filter bar cache was the only place still using the O(n) approach.

## Impact

- Eliminates O(n) hash computation on every rebuild when the filter bar is visible
- Consistent with the existing pattern in \_getFilteredEvents()\
- No behavioral change — cache still invalidates on every event mutation