### PR TITLE
security: encrypt all persistent data with flutter_secure_storage

### DIFF
--- a/lib/core/services/persistent_state_mixin.dart
+++ b/lib/core/services/persistent_state_mixin.dart
@@ -1,8 +1,14 @@
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'secure_storage_service.dart';
 
 /// Mixin for StatefulWidget states that need to persist service data
-/// across app restarts via SharedPreferences.
+/// across app restarts using encrypted storage.
+///
+/// Data is stored via [SecureStorageService] (EncryptedSharedPreferences on
+/// Android, Keychain on iOS). On first load, any existing plaintext data in
+/// SharedPreferences is automatically migrated to the encrypted store and
+/// the plaintext copy is deleted.
 ///
 /// Subclasses must implement [storageKey], [exportData], and [importData].
 /// Data is automatically saved when the app goes to background or the
@@ -28,7 +34,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// ```
 mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
     implements WidgetsBindingObserver {
-  /// SharedPreferences key for this screen's data.
+  /// Storage key for this screen's data.
   String get storageKey;
 
   /// Serialize current state to JSON string.
@@ -48,8 +54,10 @@ mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
   }
 
   Future<void> _loadData() async {
-    final prefs = await SharedPreferences.getInstance();
-    final json = prefs.getString(storageKey);
+    // Migrate plaintext SharedPreferences → encrypted storage if needed.
+    await _migrateFromPlaintext();
+
+    final json = await SecureStorageService.read(storageKey);
     if (json != null && json.isNotEmpty) {
       try {
         importData(json);
@@ -58,11 +66,31 @@ mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
     if (mounted) setState(() {});
   }
 
-  /// Save current state to SharedPreferences. Call after mutations.
-  Future<void> saveData() async {
+  /// One-time migration: move data from plaintext SharedPreferences to
+  /// encrypted storage, then delete the plaintext copy.
+  Future<void> _migrateFromPlaintext() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(storageKey, exportData());
+      final plaintext = prefs.getString(storageKey);
+      if (plaintext != null && plaintext.isNotEmpty) {
+        // Only migrate if encrypted store doesn't already have data.
+        final existing = await SecureStorageService.read(storageKey);
+        if (existing == null || existing.isEmpty) {
+          await SecureStorageService.write(storageKey, plaintext);
+        }
+        // Remove plaintext regardless (idempotent cleanup).
+        await prefs.remove(storageKey);
+      }
+    } catch (_) {
+      // Migration failure is non-fatal; data stays in plaintext until
+      // next successful migration attempt.
+    }
+  }
+
+  /// Save current state to encrypted storage. Call after mutations.
+  Future<void> saveData() async {
+    try {
+      await SecureStorageService.write(storageKey, exportData());
     } catch (_) {}
   }
 

--- a/lib/core/services/screen_persistence.dart
+++ b/lib/core/services/screen_persistence.dart
@@ -1,9 +1,14 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'secure_storage_service.dart';
 
 /// Generic persistence helper for tracker screens that store lists of entries
-/// in memory. Provides save/load via SharedPreferences using model
-/// toJson/fromJson serialization.
+/// in memory. Uses encrypted storage (EncryptedSharedPreferences on Android,
+/// Keychain on iOS) to protect sensitive health, financial, and personal data.
+///
+/// On first load, any existing plaintext data in SharedPreferences is
+/// automatically migrated to encrypted storage and the plaintext copy is
+/// deleted.
 ///
 /// Usage:
 /// ```dart
@@ -30,11 +35,29 @@ class ScreenPersistence<T> {
     required this.fromJson,
   });
 
-  /// Load all entries from SharedPreferences. Returns empty list if none.
-  Future<List<T>> load() async {
+  /// Migrate plaintext SharedPreferences data to encrypted storage.
+  /// Called automatically by [load] and [loadMap].
+  Future<void> _migrateFromPlaintext() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final data = prefs.getString(storageKey);
+      final plaintext = prefs.getString(storageKey);
+      if (plaintext != null && plaintext.isNotEmpty) {
+        final existing = await SecureStorageService.read(storageKey);
+        if (existing == null || existing.isEmpty) {
+          await SecureStorageService.write(storageKey, plaintext);
+        }
+        await prefs.remove(storageKey);
+      }
+    } catch (_) {
+      // Migration failure is non-fatal.
+    }
+  }
+
+  /// Load all entries from encrypted storage. Returns empty list if none.
+  Future<List<T>> load() async {
+    try {
+      await _migrateFromPlaintext();
+      final data = await SecureStorageService.read(storageKey);
       if (data == null || data.isEmpty) return [];
       final list = jsonDecode(data) as List<dynamic>;
       return list
@@ -45,12 +68,11 @@ class ScreenPersistence<T> {
     }
   }
 
-  /// Save all entries to SharedPreferences.
+  /// Save all entries to encrypted storage.
   Future<void> save(List<T> entries) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
       final data = jsonEncode(entries.map((e) => toJson(e)).toList());
-      await prefs.setString(storageKey, data);
+      await SecureStorageService.write(storageKey, data);
     } catch (_) {
       // Silently fail — don't crash the UI for persistence errors.
     }
@@ -58,15 +80,19 @@ class ScreenPersistence<T> {
 
   /// Delete all persisted entries.
   Future<void> clear() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(storageKey);
+    await SecureStorageService.delete(storageKey);
+    // Also clean up any remaining plaintext.
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(storageKey);
+    } catch (_) {}
   }
 
   /// Load a single JSON map (for non-list state like counters, configs).
   Future<Map<String, dynamic>?> loadMap() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final data = prefs.getString(storageKey);
+      await _migrateFromPlaintext();
+      final data = await SecureStorageService.read(storageKey);
       if (data == null || data.isEmpty) return null;
       return jsonDecode(data) as Map<String, dynamic>;
     } catch (_) {
@@ -77,8 +103,7 @@ class ScreenPersistence<T> {
   /// Save a single JSON map.
   Future<void> saveMap(Map<String, dynamic> map) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(storageKey, jsonEncode(map));
+      await SecureStorageService.write(storageKey, jsonEncode(map));
     } catch (_) {
       // Silently fail.
     }


### PR DESCRIPTION
Migrates PersistentStateMixin and ScreenPersistence from plaintext SharedPreferences to SecureStorageService (EncryptedSharedPreferences on Android, Keychain on iOS). Includes automatic one-time migration of existing plaintext data. Protects 40+ trackers storing health, financial, and personal journal data. Closes #95