### PR TITLE
security: encrypt sensitive data at rest via SecureStorageService

### DIFF
--- a/lib/core/services/data_backup_service.dart
+++ b/lib/core/services/data_backup_service.dart
@@ -1,11 +1,17 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'secure_storage_service.dart';
+
 /// Unified data backup and restore service.
 ///
 /// Discovers all registered storage keys, exports their data into a single
 /// JSON backup, and restores from a backup with optional merge/replace
 /// strategy.
+///
+/// All data is read/written via [SecureStorageService] (encrypted).
+/// During export/import, any lingering plaintext SharedPreferences data
+/// is automatically migrated to the encrypted backend.
 ///
 /// Usage:
 /// ```dart
@@ -67,14 +73,26 @@ class DataBackupService {
   ///
   /// Returns a JSON object with metadata and a `services` map where each
   /// key is a storage key and the value is the raw JSON string stored in
-  /// SharedPreferences.
+  /// encrypted storage.
   Future<String> exportAll() async {
     final prefs = await SharedPreferences.getInstance();
     final services = <String, dynamic>{};
     final supported = <String, bool>{};
 
     for (final entry in _storageKeys.entries) {
-      final data = prefs.getString(entry.key);
+      // Read from encrypted storage first
+      String? data = await SecureStorageService.read(entry.key);
+
+      // Auto-migrate from plaintext if encrypted store is empty
+      if (data == null || data.isEmpty) {
+        final plaintext = prefs.getString(entry.key);
+        if (plaintext != null && plaintext.isNotEmpty) {
+          data = plaintext;
+          await SecureStorageService.write(entry.key, plaintext);
+          await prefs.remove(entry.key);
+        }
+      }
+
       supported[entry.key] = data != null;
       if (data != null) {
         services[entry.key] = data;
@@ -164,7 +182,7 @@ class DataBackupService {
 
       // Check merge strategy
       if (strategy == BackupStrategy.merge) {
-        final existing = prefs.getString(key);
+        final existing = await SecureStorageService.read(key);
         if (existing != null && existing.isNotEmpty) {
           serviceResults[key] = 'skipped_existing';
           skipped++;
@@ -181,7 +199,9 @@ class DataBackupService {
         continue;
       }
 
-      await prefs.setString(key, value);
+      await SecureStorageService.write(key, value);
+      // Clean up any lingering plaintext
+      await prefs.remove(key);
       serviceResults[key] = 'restored';
       restored++;
     }
@@ -196,11 +216,10 @@ class DataBackupService {
 
   /// Check which services have data and which support backup.
   Future<Map<String, ServiceBackupInfo>> checkServiceSupport() async {
-    final prefs = await SharedPreferences.getInstance();
     final result = <String, ServiceBackupInfo>{};
 
     for (final entry in _storageKeys.entries) {
-      final data = prefs.getString(entry.key);
+      final data = await SecureStorageService.read(entry.key);
       result[entry.key] = ServiceBackupInfo(
         displayName: entry.value,
         hasData: data != null && data.isNotEmpty,
@@ -211,12 +230,15 @@ class DataBackupService {
     return result;
   }
 
-  /// Clear all persisted data. Use with caution.
+  /// Clear all persisted data from both encrypted and plaintext storage.
   Future<int> clearAll() async {
     final prefs = await SharedPreferences.getInstance();
     int cleared = 0;
     for (final key in _storageKeys.keys) {
-      if (prefs.containsKey(key)) {
+      final hasSecure = await SecureStorageService.containsKey(key);
+      final hasPlain = prefs.containsKey(key);
+      if (hasSecure || hasPlain) {
+        await SecureStorageService.delete(key);
         await prefs.remove(key);
         cleared++;
       }

--- a/lib/core/services/persistent_state_mixin.dart
+++ b/lib/core/services/persistent_state_mixin.dart
@@ -1,8 +1,15 @@
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'secure_storage_service.dart';
+
 /// Mixin for StatefulWidget states that need to persist service data
-/// across app restarts via SharedPreferences.
+/// across app restarts via encrypted storage.
+///
+/// Data is stored in platform-secure storage (Android EncryptedSharedPreferences /
+/// iOS Keychain) to protect sensitive health, financial, and personal data.
+/// On first load, any existing plaintext SharedPreferences data is automatically
+/// migrated to the encrypted backend and the plaintext copy is deleted.
 ///
 /// Subclasses must implement [storageKey], [exportData], and [importData].
 /// Data is automatically saved when the app goes to background or the
@@ -28,7 +35,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// ```
 mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
     implements WidgetsBindingObserver {
-  /// SharedPreferences key for this screen's data.
+  /// Storage key for this screen's data.
   String get storageKey;
 
   /// Serialize current state to JSON string.
@@ -48,8 +55,21 @@ mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
   }
 
   Future<void> _loadData() async {
-    final prefs = await SharedPreferences.getInstance();
-    final json = prefs.getString(storageKey);
+    // Try loading from encrypted storage first
+    String? json = await SecureStorageService.read(storageKey);
+
+    if (json == null || json.isEmpty) {
+      // Migrate from plaintext SharedPreferences if present
+      final prefs = await SharedPreferences.getInstance();
+      final plaintext = prefs.getString(storageKey);
+      if (plaintext != null && plaintext.isNotEmpty) {
+        json = plaintext;
+        // Migrate: write to secure storage, then delete plaintext
+        await SecureStorageService.write(storageKey, plaintext);
+        await prefs.remove(storageKey);
+      }
+    }
+
     if (json != null && json.isNotEmpty) {
       try {
         importData(json);
@@ -58,11 +78,10 @@ mixin PersistentStateMixin<T extends StatefulWidget> on State<T>
     if (mounted) setState(() {});
   }
 
-  /// Save current state to SharedPreferences. Call after mutations.
+  /// Save current state to encrypted storage. Call after mutations.
   Future<void> saveData() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(storageKey, exportData());
+      await SecureStorageService.write(storageKey, exportData());
     } catch (_) {}
   }
 

--- a/lib/core/services/screen_persistence.dart
+++ b/lib/core/services/screen_persistence.dart
@@ -1,9 +1,14 @@
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import 'secure_storage_service.dart';
+
 /// Generic persistence helper for tracker screens that store lists of entries
-/// in memory. Provides save/load via SharedPreferences using model
-/// toJson/fromJson serialization.
+/// in memory. Uses encrypted storage (Android EncryptedSharedPreferences /
+/// iOS Keychain) to protect sensitive health, financial, and personal data.
+///
+/// On first load, automatically migrates any existing plaintext
+/// SharedPreferences data to the encrypted backend.
 ///
 /// Usage:
 /// ```dart
@@ -30,11 +35,28 @@ class ScreenPersistence<T> {
     required this.fromJson,
   });
 
-  /// Load all entries from SharedPreferences. Returns empty list if none.
+  /// Migrate plaintext SharedPreferences data to secure storage if present.
+  Future<String?> _migrateIfNeeded() async {
+    final prefs = await SharedPreferences.getInstance();
+    final plaintext = prefs.getString(storageKey);
+    if (plaintext != null && plaintext.isNotEmpty) {
+      await SecureStorageService.write(storageKey, plaintext);
+      await prefs.remove(storageKey);
+      return plaintext;
+    }
+    return null;
+  }
+
+  /// Load all entries from encrypted storage. Returns empty list if none.
   Future<List<T>> load() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final data = prefs.getString(storageKey);
+      String? data = await SecureStorageService.read(storageKey);
+
+      // Auto-migrate from plaintext if encrypted store is empty
+      if (data == null || data.isEmpty) {
+        data = await _migrateIfNeeded();
+      }
+
       if (data == null || data.isEmpty) return [];
       final list = jsonDecode(data) as List<dynamic>;
       return list
@@ -45,19 +67,20 @@ class ScreenPersistence<T> {
     }
   }
 
-  /// Save all entries to SharedPreferences.
+  /// Save all entries to encrypted storage.
   Future<void> save(List<T> entries) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
       final data = jsonEncode(entries.map((e) => toJson(e)).toList());
-      await prefs.setString(storageKey, data);
+      await SecureStorageService.write(storageKey, data);
     } catch (_) {
       // Silently fail — don't crash the UI for persistence errors.
     }
   }
 
-  /// Delete all persisted entries.
+  /// Delete all persisted entries from both encrypted and plaintext storage.
   Future<void> clear() async {
+    await SecureStorageService.delete(storageKey);
+    // Also clean up any lingering plaintext data
     final prefs = await SharedPreferences.getInstance();
     await prefs.remove(storageKey);
   }
@@ -65,8 +88,12 @@ class ScreenPersistence<T> {
   /// Load a single JSON map (for non-list state like counters, configs).
   Future<Map<String, dynamic>?> loadMap() async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final data = prefs.getString(storageKey);
+      String? data = await SecureStorageService.read(storageKey);
+
+      if (data == null || data.isEmpty) {
+        data = await _migrateIfNeeded();
+      }
+
       if (data == null || data.isEmpty) return null;
       return jsonDecode(data) as Map<String, dynamic>;
     } catch (_) {
@@ -74,11 +101,10 @@ class ScreenPersistence<T> {
     }
   }
 
-  /// Save a single JSON map.
+  /// Save a single JSON map to encrypted storage.
   Future<void> saveMap(Map<String, dynamic> map) async {
     try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(storageKey, jsonEncode(map));
+      await SecureStorageService.write(storageKey, jsonEncode(map));
     } catch (_) {
       // Silently fail.
     }


### PR DESCRIPTION
Migrate all 40+ tracker services from plaintext SharedPreferences to flutter_secure_storage (EncryptedSharedPreferences on Android, Keychain on iOS).

**Changes:**
- **PersistentStateMixin**: reads/writes via SecureStorageService with auto-migration from plaintext
- **ScreenPersistence**: same encrypted backend with transparent migration
- **DataBackupService**: export/import/check/clear all use encrypted storage, cleaning up any lingering plaintext

Existing plaintext data is automatically migrated on first access and the plaintext copy is deleted — zero user action required.

Fixes #95