### PR TITLE
refactor: extract PersistedListService to eliminate SharedPreferences boilerplate

### DIFF
--- a/lib/core/services/mood_journal_service.dart
+++ b/lib/core/services/mood_journal_service.dart
@@ -1,68 +1,36 @@
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/mood_entry.dart';
+import 'persisted_list_service.dart';
 
 /// Service for managing mood journal entries with local persistence.
-class MoodJournalService {
-  static const String _storageKey = 'mood_journal_entries';
-  List<MoodEntry> _entries = [];
-  bool _initialized = false;
+///
+/// Extends [PersistedListService] for SharedPreferences-based CRUD,
+/// adding mood-specific analytics: trends, activity correlations, streaks.
+class MoodJournalService extends PersistedListService<MoodEntry> {
+  @override
+  String get storageKey => 'mood_journal_entries';
 
-  List<MoodEntry> get entries => List.unmodifiable(_entries);
+  @override
+  String encodeList(List<MoodEntry> entries) => MoodEntry.encodeList(entries);
 
-  /// Load entries from local storage.
-  Future<void> init() async {
-    if (_initialized) return;
-    final prefs = await SharedPreferences.getInstance();
-    final data = prefs.getString(_storageKey);
-    if (data != null && data.isNotEmpty) {
-      _entries = MoodEntry.decodeList(data);
-    }
-    _entries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
-    _initialized = true;
-  }
+  @override
+  List<MoodEntry> decodeList(String data) => MoodEntry.decodeList(data);
 
-  Future<void> _save() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_storageKey, MoodEntry.encodeList(_entries));
-  }
+  @override
+  String getId(MoodEntry e) => e.id;
 
-  /// Add a new mood entry.
-  Future<void> addEntry(MoodEntry entry) async {
-    await init();
-    _entries.insert(0, entry);
-    await _save();
-  }
+  @override
+  DateTime? getTimestamp(MoodEntry e) => e.timestamp;
 
-  /// Delete an entry by id.
-  Future<void> deleteEntry(String id) async {
-    await init();
-    _entries.removeWhere((e) => e.id == id);
-    await _save();
-  }
+  @override
+  int defaultSort(MoodEntry a, MoodEntry b) =>
+      b.timestamp.compareTo(a.timestamp);
 
-  /// Update an existing entry.
-  Future<void> updateEntry(MoodEntry entry) async {
-    await init();
-    final idx = _entries.indexWhere((e) => e.id == entry.id);
-    if (idx >= 0) {
-      _entries[idx] = entry;
-      await _save();
-    }
-  }
-
-  /// Get entries for a specific date.
-  List<MoodEntry> entriesForDate(DateTime date) {
-    return _entries.where((e) =>
-        e.timestamp.year == date.year &&
-        e.timestamp.month == date.month &&
-        e.timestamp.day == date.day).toList();
-  }
+  // ── Queries ──
 
   /// Get entries for the last N days.
   List<MoodEntry> entriesForLastDays(int days) {
     final cutoff = DateTime.now().subtract(Duration(days: days));
-    return _entries.where((e) => e.timestamp.isAfter(cutoff)).toList();
+    return entries.where((e) => e.timestamp.isAfter(cutoff)).toList();
   }
 
   /// Average mood for a specific date (or null if no entries).
@@ -78,7 +46,8 @@ class MoodJournalService {
     final result = <DateTime, double>{};
     final now = DateTime.now();
     for (int i = days - 1; i >= 0; i--) {
-      final date = DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
+      final date =
+          DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
       final avg = averageMoodForDate(date);
       if (avg != null) {
         result[date] = avg;
@@ -90,7 +59,7 @@ class MoodJournalService {
   /// Most common activities across all entries.
   Map<MoodActivity, int> activityFrequency() {
     final counts = <MoodActivity, int>{};
-    for (final entry in _entries) {
+    for (final entry in entries) {
       for (final activity in entry.activities) {
         counts[activity] = (counts[activity] ?? 0) + 1;
       }
@@ -104,7 +73,7 @@ class MoodJournalService {
   Map<MoodActivity, double> moodByActivity() {
     final sums = <MoodActivity, int>{};
     final counts = <MoodActivity, int>{};
-    for (final entry in _entries) {
+    for (final entry in entries) {
       for (final activity in entry.activities) {
         sums[activity] = (sums[activity] ?? 0) + entry.mood.value;
         counts[activity] = (counts[activity] ?? 0) + 1;
@@ -124,14 +93,16 @@ class MoodJournalService {
   /// Uses a pre-built set of dates for O(1) lookups instead of
   /// scanning the full entry list for each of the last 365 days.
   int currentStreak() {
-    if (_entries.isEmpty) return 0;
-    final dates = _entries
-        .map((e) => DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day))
+    if (entries.isEmpty) return 0;
+    final dates = entries
+        .map((e) =>
+            DateTime(e.timestamp.year, e.timestamp.month, e.timestamp.day))
         .toSet();
     final now = DateTime.now();
     int streak = 0;
     for (int i = 0; i < 365; i++) {
-      final date = DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
+      final date =
+          DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
       if (dates.contains(date)) {
         streak++;
       } else {

--- a/lib/core/services/persisted_list_service.dart
+++ b/lib/core/services/persisted_list_service.dart
@@ -1,0 +1,115 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Generic base class for services that persist a list of entries to
+/// SharedPreferences with lazy initialization.
+///
+/// Eliminates the init/save/addEntry/deleteEntry/updateEntry boilerplate
+/// that was duplicated across MoodJournalService, SymptomTrackerService,
+/// SleepTrackerService, and others.
+///
+/// Subclasses provide:
+/// - [storageKey]: the SharedPreferences key
+/// - [encodeList]/[decodeList]: serialization for the entry list
+/// - [getId]: extract unique id from an entry
+/// - [defaultSort]: how to sort entries after load (newest-first, etc.)
+///
+/// Example:
+/// ```dart
+/// class MoodJournalService extends PersistedListService<MoodEntry> {
+///   @override String get storageKey => 'mood_journal_entries';
+///   @override String encodeList(List<MoodEntry> entries) => MoodEntry.encodeList(entries);
+///   @override List<MoodEntry> decodeList(String data) => MoodEntry.decodeList(data);
+///   @override String getId(MoodEntry e) => e.id;
+///   @override int defaultSort(MoodEntry a, MoodEntry b) => b.timestamp.compareTo(a.timestamp);
+/// }
+/// ```
+abstract class PersistedListService<T> {
+  List<T> _entries = [];
+  bool _initialized = false;
+
+  /// Unmodifiable view of all entries.
+  List<T> get entries => List.unmodifiable(_entries);
+
+  /// The SharedPreferences key used for storage.
+  String get storageKey;
+
+  /// Serialize all entries to a string.
+  String encodeList(List<T> entries);
+
+  /// Deserialize entries from a stored string.
+  List<T> decodeList(String data);
+
+  /// Extract the unique identifier from an entry.
+  String getId(T entry);
+
+  /// Default sort comparator applied after loading. Return 0 for no sort.
+  int defaultSort(T a, T b);
+
+  /// Load entries from local storage. Safe to call multiple times.
+  Future<void> init() async {
+    if (_initialized) return;
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(storageKey);
+    if (data != null && data.isNotEmpty) {
+      _entries = decodeList(data);
+    }
+    _entries.sort(defaultSort);
+    _initialized = true;
+  }
+
+  /// Persist current entries to SharedPreferences.
+  Future<void> save() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(storageKey, encodeList(_entries));
+  }
+
+  /// Add an entry (inserted at the front for newest-first lists).
+  Future<void> addEntry(T entry) async {
+    await init();
+    _entries.insert(0, entry);
+    await save();
+  }
+
+  /// Delete an entry by id.
+  Future<void> deleteEntry(String id) async {
+    await init();
+    _entries.removeWhere((e) => getId(e) == id);
+    await save();
+  }
+
+  /// Update an existing entry. Returns true if found and updated.
+  Future<bool> updateEntry(T entry) async {
+    await init();
+    final entryId = getId(entry);
+    final idx = _entries.indexWhere((e) => getId(e) == entryId);
+    if (idx >= 0) {
+      _entries[idx] = entry;
+      await save();
+      return true;
+    }
+    return false;
+  }
+
+  /// Get entries within a date range. Subclasses must override [getTimestamp]
+  /// or use this default which returns nothing.
+  DateTime? getTimestamp(T entry) => null;
+
+  /// Get entries within a date range (requires [getTimestamp] override).
+  List<T> entriesInRange(DateTime start, DateTime end) {
+    return _entries.where((e) {
+      final ts = getTimestamp(e);
+      return ts != null && ts.isAfter(start) && ts.isBefore(end);
+    }).toList();
+  }
+
+  /// Get entries for a specific date (requires [getTimestamp] override).
+  List<T> entriesForDate(DateTime date) {
+    return _entries.where((e) {
+      final ts = getTimestamp(e);
+      return ts != null &&
+          ts.year == date.year &&
+          ts.month == date.month &&
+          ts.day == date.day;
+    }).toList();
+  }
+}

--- a/lib/core/services/symptom_tracker_service.dart
+++ b/lib/core/services/symptom_tracker_service.dart
@@ -1,62 +1,42 @@
-import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/symptom_entry.dart';
+import 'persisted_list_service.dart';
 
 /// Service for managing symptom log entries with local persistence.
-class SymptomTrackerService {
-  static const String _storageKey = 'symptom_tracker_entries';
-  List<SymptomEntry> _entries = [];
-  bool _initialized = false;
+///
+/// Extends [PersistedListService] for SharedPreferences-based CRUD,
+/// adding symptom-specific queries: body area filtering, frequency analysis.
+class SymptomTrackerService extends PersistedListService<SymptomEntry> {
+  @override
+  String get storageKey => 'symptom_tracker_entries';
 
-  List<SymptomEntry> get entries => List.unmodifiable(_entries);
+  @override
+  String encodeList(List<SymptomEntry> entries) =>
+      SymptomEntry.encodeList(entries);
 
-  /// Load entries from local storage.
-  Future<void> init() async {
-    if (_initialized) return;
-    final prefs = await SharedPreferences.getInstance();
-    final data = prefs.getString(_storageKey);
-    if (data != null && data.isNotEmpty) {
-      _entries = SymptomEntry.decodeList(data);
-    }
-    _entries.sort((a, b) => b.timestamp.compareTo(a.timestamp));
-    _initialized = true;
-  }
+  @override
+  List<SymptomEntry> decodeList(String data) => SymptomEntry.decodeList(data);
 
-  Future<void> _save() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_storageKey, SymptomEntry.encodeList(_entries));
-  }
+  @override
+  String getId(SymptomEntry e) => e.id;
 
-  /// Add a new symptom entry.
-  Future<void> addEntry(SymptomEntry entry) async {
-    await init();
-    _entries.insert(0, entry);
-    await _save();
-  }
+  @override
+  DateTime? getTimestamp(SymptomEntry e) => e.timestamp;
 
-  /// Delete an entry by id.
-  Future<void> deleteEntry(String id) async {
-    await init();
-    _entries.removeWhere((e) => e.id == id);
-    await _save();
-  }
+  @override
+  int defaultSort(SymptomEntry a, SymptomEntry b) =>
+      b.timestamp.compareTo(a.timestamp);
+
+  // ── Queries ──
 
   /// Get entries for a specific body area.
   List<SymptomEntry> entriesForArea(BodyArea area) {
-    return _entries.where((e) => e.bodyArea == area).toList();
-  }
-
-  /// Get entries within a date range.
-  List<SymptomEntry> entriesInRange(DateTime start, DateTime end) {
-    return _entries
-        .where((e) => e.timestamp.isAfter(start) && e.timestamp.isBefore(end))
-        .toList();
+    return entries.where((e) => e.bodyArea == area).toList();
   }
 
   /// Get most frequent symptoms.
   Map<String, int> symptomFrequency() {
     final freq = <String, int>{};
-    for (final e in _entries) {
+    for (final e in entries) {
       freq[e.symptom] = (freq[e.symptom] ?? 0) + 1;
     }
     return Map.fromEntries(
@@ -67,7 +47,7 @@ class SymptomTrackerService {
   /// Get most common triggers across all entries.
   Map<String, int> triggerFrequency() {
     final freq = <String, int>{};
-    for (final e in _entries) {
+    for (final e in entries) {
       for (final t in e.triggers) {
         freq[t] = (freq[t] ?? 0) + 1;
       }


### PR DESCRIPTION
Multiple services duplicate the same SharedPreferences persistence pattern (lazy init, save, add/delete/update, date filtering). Created PersistedListService as a generic base class. Refactored MoodJournalService and SymptomTrackerService to extend it. No breaking API changes.