### PR TITLE
chore: remove unused dart:convert imports

### DIFF
--- a/lib/core/services/meal_tracker_service.dart
+++ b/lib/core/services/meal_tracker_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import '../../models/meal_entry.dart';
 
 /// Nutrition goals configuration.

--- a/lib/core/services/mood_journal_service.dart
+++ b/lib/core/services/mood_journal_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/mood_entry.dart';
 import '../utils/collection_utils.dart';

--- a/lib/core/services/reading_list_service.dart
+++ b/lib/core/services/reading_list_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import '../../models/book.dart';
 import 'crud_service.dart';
 

--- a/lib/core/services/symptom_tracker_service.dart
+++ b/lib/core/services/symptom_tracker_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../models/symptom_entry.dart';
 

--- a/lib/core/services/world_clock_service.dart
+++ b/lib/core/services/world_clock_service.dart
@@ -1,4 +1,3 @@
-import 'dart:convert';
 import '../services/persistent_state_mixin.dart';
 import '../../models/world_clock_entry.dart';
 


### PR DESCRIPTION
Removed unused \dart:convert\ imports from 5 service files that don't use any dart:convert APIs (jsonEncode, jsonDecode, utf8, etc.).

**Files cleaned:**
- \meal_tracker_service.dart\
- \mood_journal_service.dart\
- \eading_list_service.dart\
- \symptom_tracker_service.dart\
- \world_clock_service.dart\
