### PR TITLE
perf: precompute lowercase search labels in FeatureEntry

### DIFF
--- a/lib/core/utils/feature_registry.dart
+++ b/lib/core/utils/feature_registry.dart
@@ -113,16 +113,24 @@ import '../../views/home/roman_numeral_screen.dart';
 /// A single navigable feature in the app.
 class FeatureEntry {
   final String label;
+
+  /// Pre-computed lowercase label for search filtering.
+  ///
+  /// The navigation drawer calls `_filteredFeatures()` on every
+  /// keystroke, which previously ran `label.toLowerCase()` on all
+  /// 100+ entries per rebuild. Caching the lowercase form here
+  /// eliminates ~100 string allocations per keystroke.
+  final String searchLabel;
   final IconData icon;
   final WidgetBuilder builder;
   final FeatureCategory category;
 
-  const FeatureEntry({
+  FeatureEntry({
     required this.label,
     required this.icon,
     required this.builder,
     required this.category,
-  });
+  }) : searchLabel = label.toLowerCase();
 }
 
 /// Categories for organizing features in the navigation drawer.

--- a/lib/views/widgets/feature_drawer.dart
+++ b/lib/views/widgets/feature_drawer.dart
@@ -25,7 +25,7 @@ class _FeatureDrawerState extends State<FeatureDrawer> {
   List<FeatureEntry> _filteredFeatures() {
     if (_query.isEmpty) return FeatureRegistry.features;
     return FeatureRegistry.features
-        .where((f) => f.label.toLowerCase().contains(_query))
+        .where((f) => f.searchLabel.contains(_query))
         .toList();
   }
 


### PR DESCRIPTION
The navigation drawer filters 100+ features on every keystroke, previously calling \label.toLowerCase()\ on each entry per rebuild.

### Changes
- Add \searchLabel\ field to \FeatureEntry\ that caches the lowercase label at construction time
- Update \FeatureDrawer._filteredFeatures()\ to use \searchLabel\ instead of \	oLowerCase()\
- Eliminates ~100 string allocations per keystroke during search
