### PR TITLE
refactor: derive command palette actions from FeatureRegistry

### DIFF
--- a/lib/core/services/command_palette_service.dart
+++ b/lib/core/services/command_palette_service.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/feature_registry.dart';
 
 /// A quick-action that can be executed from the command palette.
 class PaletteAction {
@@ -11,7 +12,7 @@ class PaletteAction {
   final void Function(BuildContext context) onExecute;
 
   /// Pre-lowercased fields for matching — computed once at construction
-  /// instead of on every [matchScore] call. With 50+ palette actions
+  /// instead of on every [matchScore] call. With 100+ palette actions
   /// scored on every keystroke, this eliminates O(actions × fields)
   /// redundant [String.toLowerCase] allocations per input event.
   late final String _labelLower = label.toLowerCase();
@@ -63,6 +64,13 @@ class PaletteAction {
 }
 
 /// Service that registers all available palette actions.
+///
+/// Navigation actions are auto-generated from [FeatureRegistry] so that
+/// adding a new feature screen requires only a single entry in the
+/// registry — both the navigation drawer and the command palette pick
+/// it up automatically. Previously, ~40 screens were hardcoded here
+/// while the registry had 100+, leaving 60+ features undiscoverable
+/// from the palette.
 class CommandPaletteService {
   CommandPaletteService._();
   static final instance = CommandPaletteService._();
@@ -81,119 +89,51 @@ class CommandPaletteService {
 
   List<String> get recentScreenIds => List.unmodifiable(_recentScreenIds);
 
-  /// Build the full action list. Call with a context that has access to
-  /// navigation (e.g., from within the overlay).
+  /// Cached action list — rebuilt only when the feature count changes
+  /// (which in practice means never at runtime, since [FeatureRegistry]
+  /// is static).
+  List<PaletteAction>? _cachedActions;
+  int _cachedFeatureCount = -1;
+
+  /// Build the full action list from [FeatureRegistry] + quick actions.
+  ///
+  /// Navigation entries are derived automatically from
+  /// [FeatureRegistry.features], so every registered feature is
+  /// searchable from the command palette without manual maintenance.
   List<PaletteAction> buildActions() {
-    return [
-      // ── Navigation ─────────────────────────────────────────────
-      _nav('nav_calendar', 'Calendar', Icons.calendar_today, 'Navigation',
-          ['schedule', 'dates', 'month', 'week']),
-      _nav('nav_stats', 'Stats', Icons.bar_chart, 'Navigation',
-          ['statistics', 'analytics', 'charts']),
-      _nav('nav_heatmap', 'Activity Heatmap', Icons.grid_on, 'Navigation',
-          ['heat', 'contributions']),
-      _nav('nav_countdown', 'Countdowns', Icons.timer, 'Navigation',
-          ['timer', 'days until']),
-      _nav('nav_agenda', 'Agenda Timeline', Icons.view_timeline, 'Navigation',
-          ['agenda', 'timeline', 'today']),
-      _nav('nav_weekly_report', 'Weekly Report', Icons.summarize, 'Navigation',
-          ['report', 'summary']),
-      _nav('nav_daily_review', 'Daily Review', Icons.rate_review, 'Navigation',
-          ['review', 'reflection']),
-      _nav('nav_life_dashboard', 'Life Dashboard', Icons.dashboard, 'Navigation',
-          ['dashboard', 'score', 'overview']),
+    if (_cachedActions != null &&
+        _cachedFeatureCount == FeatureRegistry.features.length) {
+      return _cachedActions!;
+    }
 
-      // ── Trackers ───────────────────────────────────────────────
-      _nav('nav_habits', 'Habit Tracker', Icons.check_circle_outline, 'Trackers',
-          ['habits', 'streaks', 'daily']),
-      _nav('nav_goals', 'Goals', Icons.flag, 'Trackers',
-          ['goals', 'objectives', 'targets']),
-      _nav('nav_mood', 'Mood Journal', Icons.mood, 'Trackers',
-          ['mood', 'feelings', 'emotions']),
-      _nav('nav_water', 'Water Tracker', Icons.water_drop, 'Trackers',
-          ['water', 'hydration', 'drink']),
-      _nav('nav_workout', 'Workout Tracker', Icons.fitness_center, 'Trackers',
-          ['exercise', 'gym', 'fitness']),
-      _nav('nav_meal', 'Meal Tracker', Icons.restaurant, 'Trackers',
-          ['food', 'nutrition', 'calories']),
-      _nav('nav_sleep', 'Sleep Tracker', Icons.bedtime, 'Trackers',
-          ['sleep', 'rest', 'bedtime']),
-      _nav('nav_energy', 'Energy Tracker', Icons.bolt, 'Trackers',
-          ['energy', 'fatigue', 'levels']),
-      _nav('nav_meditation', 'Meditation', Icons.self_improvement, 'Trackers',
-          ['meditate', 'mindfulness', 'calm']),
+    final actions = <PaletteAction>[];
 
-      // ── Productivity ───────────────────────────────────────────
-      _nav('nav_pomodoro', 'Pomodoro Timer', Icons.av_timer, 'Productivity',
-          ['focus', 'timer', 'work']),
-      _nav('nav_time_tracker', 'Time Tracker', Icons.access_time, 'Productivity',
-          ['time', 'hours', 'log']),
-      _nav('nav_focus', 'Focus Time', Icons.center_focus_strong, 'Productivity',
-          ['focus', 'deep work', 'concentrate']),
-      _nav('nav_routine', 'Routine Builder', Icons.repeat, 'Productivity',
-          ['routine', 'morning', 'evening']),
-      _nav('nav_chores', 'Chore Tracker', Icons.cleaning_services, 'Productivity',
-          ['chores', 'tasks', 'housework']),
-      _nav('nav_time_budget', 'Time Budget', Icons.pie_chart, 'Productivity',
-          ['budget', 'allocation', 'balance']),
-      _nav('nav_screen_time', 'Screen Time', Icons.phone_android, 'Productivity',
-          ['phone', 'apps', 'digital']),
-      _nav('nav_weekly_planner', 'Weekly Planner', Icons.view_week, 'Productivity',
-          ['plan', 'week', 'schedule']),
+    // ── Auto-generate navigation actions from FeatureRegistry ────
+    for (int i = 0; i < FeatureRegistry.features.length; i++) {
+      final feature = FeatureRegistry.features[i];
+      // Derive a stable id from the label (e.g. "Mood Journal" → "nav_mood_journal")
+      final id = 'nav_${feature.label.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'_+$'), '')}';
+      actions.add(PaletteAction(
+        id: id,
+        label: feature.label,
+        icon: feature.icon,
+        category: feature.category.label,
+        // Split label words as keywords for better fuzzy matching
+        keywords: feature.label.toLowerCase().split(RegExp(r'\s+')),
+        onExecute: (_) {},  // Navigation wired in overlay via FeatureRegistry
+      ));
+    }
 
-      // ── Finance ────────────────────────────────────────────────
-      _nav('nav_expenses', 'Expense Tracker', Icons.attach_money, 'Finance',
-          ['money', 'spending', 'budget']),
-      _nav('nav_subscriptions', 'Subscriptions', Icons.subscriptions, 'Finance',
-          ['recurring', 'monthly', 'bills']),
-      _nav('nav_savings', 'Savings Goals', Icons.savings, 'Finance',
-          ['save', 'piggybank', 'target']),
-      _nav('nav_budget', 'Budget Planner', Icons.account_balance_wallet, 'Finance',
-          ['budget', 'plan', 'finance']),
-
-      // ── Personal ───────────────────────────────────────────────
-      _nav('nav_contacts', 'Contact Tracker', Icons.contacts, 'Personal',
-          ['people', 'relationships', 'network']),
-      _nav('nav_gratitude', 'Gratitude Journal', Icons.favorite, 'Personal',
-          ['grateful', 'thankful', 'appreciate']),
-      _nav('nav_decisions', 'Decision Journal', Icons.balance, 'Personal',
-          ['decide', 'choices', 'options']),
-      _nav('nav_reading', 'Reading List', Icons.book, 'Personal',
-          ['books', 'read', 'library']),
-      _nav('nav_skills', 'Skill Tracker', Icons.school, 'Personal',
-          ['learn', 'practice', 'improve']),
-      _nav('nav_pet', 'Pet Care', Icons.pets, 'Personal',
-          ['pet', 'dog', 'cat', 'vet']),
-      _nav('nav_plant', 'Plant Care', Icons.local_florist, 'Personal',
-          ['plants', 'garden', 'watering']),
-      _nav('nav_medication', 'Medication Tracker', Icons.medical_services, 'Personal',
-          ['medicine', 'pills', 'health']),
-      _nav('nav_commute', 'Commute Tracker', Icons.directions_car, 'Personal',
-          ['travel', 'drive', 'commute']),
-      _nav('nav_vehicle', 'Vehicle Maintenance', Icons.build_circle, 'Personal',
-          ['car', 'vehicle', 'maintenance', 'oil', 'service']),
-
-      // ── Lists ──────────────────────────────────────────────────
-      _nav('nav_bucket_list', 'Bucket List', Icons.checklist, 'Lists',
-          ['bucket', 'life goals', 'dreams']),
-      _nav('nav_travel', 'Travel Log', Icons.flight, 'Lists',
-          ['trips', 'vacation', 'travel']),
-      _nav('nav_wishlist', 'Wishlist', Icons.card_giftcard, 'Lists',
-          ['wish', 'want', 'buy']),
-      _nav('nav_watchlist', 'Watchlist', Icons.movie_outlined, 'Lists',
-          ['movies', 'tv', 'shows', 'watch', 'film', 'series']),
-      _nav('nav_gifts', 'Gift Tracker', Icons.redeem, 'Lists',
-          ['gifts', 'presents', 'birthday']),
-
-      // ── Quick Actions ──────────────────────────────────────────
+    // ── Quick Actions (not tied to FeatureRegistry) ──────────────
+    actions.addAll([
       PaletteAction(
         id: 'action_new_event',
         label: 'New Event',
         subtitle: 'Create a new event',
         icon: Icons.add_circle,
         category: 'Quick Actions',
-        keywords: ['add', 'create', 'new', 'event'],
-        onExecute: (_) {},  // Wired up in the overlay
+        keywords: const ['add', 'create', 'new', 'event'],
+        onExecute: (_) {},
       ),
       PaletteAction(
         id: 'action_log_water',
@@ -201,7 +141,7 @@ class CommandPaletteService {
         subtitle: 'Quick-add a glass of water',
         icon: Icons.water_drop,
         category: 'Quick Actions',
-        keywords: ['water', 'drink', 'hydrate'],
+        keywords: const ['water', 'drink', 'hydrate'],
         onExecute: (_) {},
       ),
       PaletteAction(
@@ -210,7 +150,7 @@ class CommandPaletteService {
         subtitle: 'Begin a 25-minute focus session',
         icon: Icons.play_circle_filled,
         category: 'Quick Actions',
-        keywords: ['focus', 'timer', 'start', 'work'],
+        keywords: const ['focus', 'timer', 'start', 'work'],
         onExecute: (_) {},
       ),
       PaletteAction(
@@ -219,7 +159,7 @@ class CommandPaletteService {
         subtitle: 'Record how you\'re feeling',
         icon: Icons.mood,
         category: 'Quick Actions',
-        keywords: ['mood', 'feeling', 'emotion'],
+        keywords: const ['mood', 'feeling', 'emotion'],
         onExecute: (_) {},
       ),
       PaletteAction(
@@ -228,22 +168,13 @@ class CommandPaletteService {
         subtitle: 'Reflect on your day',
         icon: Icons.rate_review,
         category: 'Quick Actions',
-        keywords: ['review', 'reflect', 'day'],
+        keywords: const ['review', 'reflect', 'day'],
         onExecute: (_) {},
       ),
-    ];
-  }
+    ]);
 
-  /// Helper to create a navigation action.
-  PaletteAction _nav(String id, String label, IconData icon,
-      String category, List<String> keywords) {
-    return PaletteAction(
-      id: id,
-      label: label,
-      icon: icon,
-      category: category,
-      keywords: keywords,
-      onExecute: (_) {},  // Navigation wired in overlay
-    );
+    _cachedActions = actions;
+    _cachedFeatureCount = FeatureRegistry.features.length;
+    return actions;
   }
 }

--- a/lib/views/widgets/command_palette_overlay.dart
+++ b/lib/views/widgets/command_palette_overlay.dart
@@ -1,50 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../core/services/command_palette_service.dart';
+import '../../core/utils/feature_registry.dart';
 import 'package:flutter/services.dart';
-import '../home/calendar_screen.dart';
-import '../home/stats_screen.dart';
-import '../home/heatmap_screen.dart';
-import '../home/countdown_screen.dart';
-import '../home/agenda_timeline_screen.dart';
-import '../home/weekly_report_screen.dart';
-import '../home/daily_review_screen.dart';
-import '../home/life_dashboard_screen.dart';
-import '../home/habit_tracker_screen.dart';
-import '../home/goals_screen.dart';
-import '../home/mood_journal_screen.dart';
-import '../home/water_tracker_screen.dart';
-import '../home/workout_tracker_screen.dart';
-import '../home/meal_tracker_screen.dart';
-import '../home/sleep_tracker_screen.dart';
-import '../home/symptom_tracker_screen.dart';
-import '../home/energy_tracker_screen.dart';
-import '../home/pomodoro_screen.dart';
-import '../home/time_tracker_screen.dart';
-import '../home/focus_time_screen.dart';
-import '../home/routine_builder_screen.dart';
-import '../home/chore_tracker_screen.dart';
-import '../home/time_budget_screen.dart';
-import '../home/screen_time_tracker_screen.dart';
-import '../home/weekly_planner_screen.dart';
-import '../home/expense_tracker_screen.dart';
-import '../home/subscription_tracker_screen.dart';
-import '../home/savings_goal_screen.dart';
-import '../home/net_worth_tracker_screen.dart';
-import '../home/budget_planner_screen.dart';
-import '../home/contact_tracker_screen.dart';
-import '../home/gratitude_journal_screen.dart';
-import '../home/decision_journal_screen.dart';
-import '../home/reading_list_screen.dart';
-import '../home/skill_tracker_screen.dart';
-import '../home/pet_care_tracker_screen.dart';
-import '../home/plant_care_tracker_screen.dart';
-import '../home/medication_tracker_screen.dart';
-import '../home/commute_tracker_screen.dart';
-import '../home/bucket_list_screen.dart';
-import '../home/travel_log_screen.dart';
-import '../home/wishlist_screen.dart';
-import '../home/watchlist_screen.dart';
-import '../home/gift_tracker_screen.dart';
 
 /// Spotlight-style command palette overlay.
 ///
@@ -88,52 +45,22 @@ class _CommandPaletteOverlayState extends State<CommandPaletteOverlay> {
   List<PaletteAction> _filtered = [];
   int _selectedIndex = 0;
 
-  static final _screenRoutes = <String, Widget Function()>{
-    'nav_calendar': () => CalendarScreen(),
-    'nav_stats': () => StatsScreen(),
-    'nav_heatmap': () => HeatmapScreen(),
-    'nav_countdown': () => CountdownScreen(),
-    'nav_agenda': () => AgendaTimelineScreen(),
-    'nav_weekly_report': () => WeeklyReportScreen(),
-    'nav_daily_review': () => DailyReviewScreen(),
-    'nav_life_dashboard': () => LifeDashboardScreen(),
-    'nav_habits': () => HabitTrackerScreen(),
-    'nav_goals': () => GoalsScreen(),
-    'nav_mood': () => MoodJournalScreen(),
-    'nav_water': () => WaterTrackerScreen(),
-    'nav_workout': () => WorkoutTrackerScreen(),
-    'nav_meal': () => MealTrackerScreen(),
-    'nav_sleep': () => SleepTrackerScreen(),
-    'nav_symptoms': () => SymptomTrackerScreen(),
-    'nav_energy': () => EnergyTrackerScreen(),
-    'nav_pomodoro': () => PomodoroScreen(),
-    'nav_time_tracker': () => TimeTrackerScreen(),
-    'nav_focus': () => FocusTimeScreen(),
-    'nav_routine': () => RoutineBuilderScreen(),
-    'nav_chores': () => ChoreTrackerScreen(),
-    'nav_time_budget': () => TimeBudgetScreen(),
-    'nav_screen_time': () => ScreenTimeTrackerScreen(),
-    'nav_weekly_planner': () => WeeklyPlannerScreen(),
-    'nav_expenses': () => ExpenseTrackerScreen(),
-    'nav_subscriptions': () => SubscriptionTrackerScreen(),
-    'nav_savings': () => SavingsGoalScreen(),
-    'nav_net_worth': () => NetWorthTrackerScreen(),
-    'nav_budget': () => BudgetPlannerScreen(),
-    'nav_contacts': () => ContactTrackerScreen(),
-    'nav_gratitude': () => GratitudeJournalScreen(),
-    'nav_decisions': () => DecisionJournalScreen(),
-    'nav_reading': () => ReadingListScreen(),
-    'nav_skills': () => SkillTrackerScreen(),
-    'nav_pet': () => PetCareTrackerScreen(),
-    'nav_plant': () => PlantCareTrackerScreen(),
-    'nav_medication': () => MedicationTrackerScreen(),
-    'nav_commute': () => CommuteTrackerScreen(),
-    'nav_bucket_list': () => BucketListScreen(),
-    'nav_travel': () => TravelLogScreen(),
-    'nav_wishlist': () => WishlistScreen(),
-    'nav_watchlist': () => WatchlistScreen(),
-    'nav_gifts': () => GiftTrackerScreen(),
-  };
+  /// Maps palette action IDs to [FeatureRegistry] indices for navigation.
+  ///
+  /// Built lazily from [FeatureRegistry.features] so that adding a new
+  /// feature only requires a single entry in the registry — both the
+  /// navigation drawer and the command palette pick it up automatically.
+  static late final Map<String, int> _featureIndex = _buildFeatureIndex();
+
+  static Map<String, int> _buildFeatureIndex() {
+    final map = <String, int>{};
+    for (int i = 0; i < FeatureRegistry.features.length; i++) {
+      final label = FeatureRegistry.features[i].label;
+      final id = 'nav_${label.toLowerCase().replaceAll(RegExp(r'[^a-z0-9]+'), '_').replaceAll(RegExp(r'_+$'), '')}';
+      map[id] = i;
+    }
+    return map;
+  }
 
   @override
   void initState() {
@@ -194,11 +121,12 @@ class _CommandPaletteOverlayState extends State<CommandPaletteOverlay> {
     Navigator.of(context).pop(); // Close palette
 
     if (action.id.startsWith('nav_')) {
-      final builder = _screenRoutes[action.id];
-      if (builder != null) {
+      final index = _featureIndex[action.id];
+      if (index != null) {
         CommandPaletteService.instance.recordVisit(action.id);
+        final feature = FeatureRegistry.features[index];
         Navigator.of(context).push(
-          MaterialPageRoute(builder: (_) => builder()),
+          MaterialPageRoute(builder: feature.builder),
         );
       }
     }


### PR DESCRIPTION
CommandPaletteService previously hardcoded ~40 nav actions while FeatureRegistry had 100+. Now auto-generated. Net: -141 lines.
