### PR TITLE
perf: parallelize backup export and service support reads

### DIFF
--- a/lib/core/services/data_backup_service.dart
+++ b/lib/core/services/data_backup_service.dart
@@ -92,15 +92,19 @@ class DataBackupService {
   ///
   /// Sensitive keys are transparently decrypted before export so the
   /// backup contains readable JSON regardless of at-rest encryption.
+  ///
+  /// All storage keys are read concurrently via [Future.wait] to reduce
+  /// total export time from O(n × latency) to O(latency) — a significant
+  /// improvement when many tracker screens have data, especially on
+  /// devices where [StorageBackend] involves async decryption.
   Future<String> exportAll() async {
-    final services = <String, dynamic>{};
-    final supported = <String, bool>{};
+    final keys = _storageKeys.keys.toList();
+    final values = await Future.wait(keys.map(_readKey));
 
-    for (final entry in _storageKeys.entries) {
-      final data = await _readKey(entry.key);
-      supported[entry.key] = data != null;
-      if (data != null) {
-        services[entry.key] = data;
+    final services = <String, dynamic>{};
+    for (var i = 0; i < keys.length; i++) {
+      if (values[i] != null) {
+        services[keys[i]] = values[i];
       }
     }
 
@@ -218,13 +222,17 @@ class DataBackupService {
   }
 
   /// Check which services have data and which support backup.
+  ///
+  /// Reads all keys concurrently for the same latency win as [exportAll].
   Future<Map<String, ServiceBackupInfo>> checkServiceSupport() async {
-    final result = <String, ServiceBackupInfo>{};
+    final entries = _storageKeys.entries.toList();
+    final values = await Future.wait(entries.map((e) => _readKey(e.key)));
 
-    for (final entry in _storageKeys.entries) {
-      final data = await _readKey(entry.key);
-      result[entry.key] = ServiceBackupInfo(
-        displayName: entry.value,
+    final result = <String, ServiceBackupInfo>{};
+    for (var i = 0; i < entries.length; i++) {
+      final data = values[i];
+      result[entries[i].key] = ServiceBackupInfo(
+        displayName: entries[i].value,
         hasData: data != null && data.isNotEmpty,
         dataSize: data?.length ?? 0,
       );


### PR DESCRIPTION
## Summary

Parallelizes all storage key reads in DataBackupService.exportAll() and checkServiceSupport() using Future.wait instead of sequential await loops.

## Problem

With 60+ storage keys (many requiring async decryption via EncryptedPreferencesService), the export/check operations were reading keys one at a time: O(n * latency).

## Fix

Read all keys concurrently with Future.wait(keys.map(_readKey)), reducing total time to O(latency).

## Changes

- exportAll(): concurrent key reads, removed unused supported map
- checkServiceSupport(): concurrent key reads with index-based result assembly
