### PR TITLE
refactor: route ServicePersistence through StorageBackend for encryption

### DIFF
--- a/lib/core/services/service_persistence.dart
+++ b/lib/core/services/service_persistence.dart
@@ -1,10 +1,12 @@
 import 'dart:convert';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'storage_backend.dart';
 
-/// Mixin for adding SharedPreferences-based persistence to stateful services.
+/// Mixin for adding persistence to stateful services.
 ///
-/// Services that hold in-memory state (lists, maps) can use this mixin to
-/// automatically save/restore their data across app restarts.
+/// Routes all storage through [StorageBackend], which automatically
+/// encrypts sensitive keys (medical, financial, diary data) via
+/// [EncryptedPreferencesService] while using plain SharedPreferences
+/// for non-sensitive keys.
 ///
 /// Usage:
 /// ```dart
@@ -22,7 +24,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// }
 /// ```
 mixin ServicePersistence {
-  /// Unique key for SharedPreferences storage.
+  /// Unique key for storage. Sensitive keys are automatically encrypted.
   String get storageKey;
 
   /// Serialize service state to JSON-compatible map.
@@ -36,10 +38,12 @@ mixin ServicePersistence {
   /// Whether persistence has been initialized (data loaded).
   bool get isInitialized => _persInitialized;
 
-  /// Load state from SharedPreferences. Call once at startup or before first use.
+  /// Load state from storage. Call once at startup or before first use.
+  ///
+  /// Sensitive keys are transparently decrypted. Existing plaintext
+  /// data for sensitive keys is migrated to encrypted form on first read.
   Future<bool> loadState() async {
-    final prefs = await SharedPreferences.getInstance();
-    final data = prefs.getString(storageKey);
+    final data = await StorageBackend.read(storageKey);
     if (data != null && data.isNotEmpty) {
       try {
         final json = jsonDecode(data) as Map<String, dynamic>;
@@ -56,15 +60,15 @@ mixin ServicePersistence {
     return false;
   }
 
-  /// Save current state to SharedPreferences.
+  /// Save current state to storage.
+  ///
+  /// Sensitive keys are automatically encrypted before storage.
   Future<void> saveState() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(storageKey, jsonEncode(toStorageJson()));
+    await StorageBackend.write(storageKey, jsonEncode(toStorageJson()));
   }
 
   /// Clear persisted state.
   Future<void> clearState() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.remove(storageKey);
+    await StorageBackend.remove(storageKey);
   }
 }


### PR DESCRIPTION
## Problem

ServicePersistence mixin was accessing SharedPreferences directly, bypassing the StorageBackend layer. 5 services with sensitive storage keys (expense_tracker, contact_tracker, gratitude_journal, goal_tracker, habit_tracker) stored personal/financial data as plaintext on disk.

## Fix

Replaced direct SharedPreferences calls with StorageBackend.read/write/remove. Sensitive keys now transparently encrypted via EncryptedPreferencesService (AES-256-GCM). Zero API changes. Existing plaintext data auto-migrated on first read.