### PR TITLE
security: prevent ReDoS in regex tester via isolate timeout and input limits

### DIFF
--- a/lib/core/services/regex_tester_service.dart
+++ b/lib/core/services/regex_tester_service.dart
@@ -1,16 +1,43 @@
+import 'dart:async';
+import 'dart:isolate';
+
 /// Service for regex testing and pattern analysis.
+///
+/// User-supplied regular expressions are executed in a separate [Isolate]
+/// with a hard timeout to prevent ReDoS (Regular Expression Denial of
+/// Service) attacks where a crafted pattern + input can lock the UI
+/// thread for minutes or longer.
 class RegexTesterService {
   RegexTesterService._();
 
+  /// Maximum allowed input length (100 KB).
+  ///
+  /// Longer inputs increase the worst-case cost of pathological patterns
+  /// exponentially. 100 KB is generous for any reasonable testing scenario.
+  static const int maxInputLength = 100 * 1024;
+
+  /// Maximum allowed pattern length (1 KB).
+  static const int maxPatternLength = 1024;
+
+  /// Timeout for regex execution in the isolate.
+  static const Duration executionTimeout = Duration(seconds: 3);
+
+  /// Maximum number of matches returned to avoid memory exhaustion.
+  static const int maxMatches = 1000;
+
   /// Test a regex pattern against input text and return all matches.
-  static RegexTestResult test({
+  ///
+  /// Runs the regex in a separate [Isolate] with a [executionTimeout]
+  /// to prevent ReDoS from freezing the app. Returns an error result
+  /// if the pattern is too complex or the input is too large.
+  static Future<RegexTestResult> test({
     required String pattern,
     required String input,
     bool caseSensitive = true,
     bool multiLine = false,
     bool dotAll = false,
     bool unicode = false,
-  }) {
+  }) async {
     if (pattern.isEmpty) {
       return const RegexTestResult(
         matches: [],
@@ -20,42 +47,152 @@ class RegexTesterService {
       );
     }
 
+    // Enforce input length limits before spawning an isolate.
+    if (pattern.length > maxPatternLength) {
+      return RegexTestResult(
+        matches: const [],
+        matchCount: 0,
+        groupCount: 0,
+        error: 'Pattern exceeds maximum length of $maxPatternLength characters.',
+      );
+    }
+
+    if (input.length > maxInputLength) {
+      return RegexTestResult(
+        matches: const [],
+        matchCount: 0,
+        groupCount: 0,
+        error: 'Input exceeds maximum length of '
+            '${maxInputLength ~/ 1024} KB.',
+      );
+    }
+
+    // Run regex matching in an isolate with a timeout so a pathological
+    // pattern cannot block the UI thread or run indefinitely.
     try {
-      final regex = RegExp(
-        pattern,
+      final result = await _runInIsolate(
+        pattern: pattern,
+        input: input,
         caseSensitive: caseSensitive,
         multiLine: multiLine,
         dotAll: dotAll,
         unicode: unicode,
+      ).timeout(executionTimeout);
+
+      return result;
+    } on TimeoutException {
+      return const RegexTestResult(
+        matches: [],
+        matchCount: 0,
+        groupCount: 0,
+        error: 'Pattern evaluation timed out — the regex may be too complex '
+            'or vulnerable to catastrophic backtracking (ReDoS). '
+            'Try simplifying the pattern or reducing the input size.',
+      );
+    }
+  }
+
+  /// Executes regex matching inside a short-lived [Isolate].
+  static Future<RegexTestResult> _runInIsolate({
+    required String pattern,
+    required String input,
+    required bool caseSensitive,
+    required bool multiLine,
+    required bool dotAll,
+    required bool unicode,
+  }) async {
+    final receivePort = ReceivePort();
+
+    late final Isolate isolate;
+    try {
+      isolate = await Isolate.spawn(
+        _isolateWorker,
+        _IsolateRequest(
+          pattern: pattern,
+          input: input,
+          caseSensitive: caseSensitive,
+          multiLine: multiLine,
+          dotAll: dotAll,
+          unicode: unicode,
+          sendPort: receivePort.sendPort,
+        ),
       );
 
-      final matches = regex.allMatches(input).toList();
-      final matchDetails = matches.map((m) {
+      final response = await receivePort.first;
+      if (response is RegexTestResult) {
+        return response;
+      }
+      // Unexpected type — treat as error.
+      return RegexTestResult(
+        matches: const [],
+        matchCount: 0,
+        groupCount: 0,
+        error: 'Unexpected isolate response: ${response.runtimeType}',
+      );
+    } catch (e) {
+      return RegexTestResult(
+        matches: const [],
+        matchCount: 0,
+        groupCount: 0,
+        error: 'Failed to run regex: $e',
+      );
+    } finally {
+      receivePort.close();
+      // Kill the isolate in case it's still running (timeout path).
+      try {
+        isolate.kill(priority: Isolate.immediate);
+      } catch (_) {
+        // Isolate may already be dead.
+      }
+    }
+  }
+
+  /// Entry point for the regex-matching isolate.
+  static void _isolateWorker(_IsolateRequest request) {
+    try {
+      final regex = RegExp(
+        request.pattern,
+        caseSensitive: request.caseSensitive,
+        multiLine: request.multiLine,
+        dotAll: request.dotAll,
+        unicode: request.unicode,
+      );
+
+      final allMatches = regex.allMatches(request.input);
+      final matchDetails = <RegexMatchDetail>[];
+      var count = 0;
+
+      for (final m in allMatches) {
+        if (count >= maxMatches) break;
         final groups = <int, String?>{};
         for (var i = 0; i <= m.groupCount; i++) {
           groups[i] = m.group(i);
         }
-        return RegexMatchDetail(
+        matchDetails.add(RegexMatchDetail(
           fullMatch: m.group(0) ?? '',
           start: m.start,
           end: m.end,
           groups: groups,
-        );
-      }).toList();
+        ));
+        count++;
+      }
 
-      return RegexTestResult(
+      request.sendPort.send(RegexTestResult(
         matches: matchDetails,
         matchCount: matchDetails.length,
-        groupCount: matches.isNotEmpty ? matches.first.groupCount : 0,
+        groupCount: allMatches.isNotEmpty
+            ? matchDetails.first.groups.length - 1
+            : 0,
         error: null,
-      );
+        truncated: count >= maxMatches,
+      ));
     } catch (e) {
-      return RegexTestResult(
-        matches: [],
+      request.sendPort.send(RegexTestResult(
+        matches: const [],
         matchCount: 0,
         groupCount: 0,
         error: e.toString(),
-      );
+      ));
     }
   }
 
@@ -76,17 +213,42 @@ class RegexTesterService {
   };
 }
 
+/// Internal request message sent to the regex isolate.
+class _IsolateRequest {
+  final String pattern;
+  final String input;
+  final bool caseSensitive;
+  final bool multiLine;
+  final bool dotAll;
+  final bool unicode;
+  final SendPort sendPort;
+
+  const _IsolateRequest({
+    required this.pattern,
+    required this.input,
+    required this.caseSensitive,
+    required this.multiLine,
+    required this.dotAll,
+    required this.unicode,
+    required this.sendPort,
+  });
+}
+
 class RegexTestResult {
   final List<RegexMatchDetail> matches;
   final int matchCount;
   final int groupCount;
   final String? error;
 
+  /// True if matches were capped at [RegexTesterService.maxMatches].
+  final bool truncated;
+
   const RegexTestResult({
     required this.matches,
     required this.matchCount,
     required this.groupCount,
     required this.error,
+    this.truncated = false,
   });
 }
 

--- a/lib/views/home/regex_tester_screen.dart
+++ b/lib/views/home/regex_tester_screen.dart
@@ -3,6 +3,9 @@ import '../../core/services/regex_tester_service.dart';
 
 /// Interactive regex tester with live match highlighting,
 /// capture groups display, and a library of common patterns.
+///
+/// Regex evaluation runs in a background [Isolate] with a timeout
+/// to protect against ReDoS (catastrophic backtracking).
 class RegexTesterScreen extends StatefulWidget {
   const RegexTesterScreen({super.key});
 
@@ -18,6 +21,10 @@ class _RegexTesterScreenState extends State<RegexTesterScreen> {
   bool _dotAll = false;
   bool _unicode = false;
   RegexTestResult? _result;
+  bool _isEvaluating = false;
+
+  /// Monotonically increasing request counter to discard stale results.
+  int _requestId = 0;
 
   @override
   void initState() {
@@ -33,8 +40,11 @@ class _RegexTesterScreenState extends State<RegexTesterScreen> {
     super.dispose();
   }
 
-  void _onChanged() {
-    final result = RegexTesterService.test(
+  void _onChanged() async {
+    final id = ++_requestId;
+    setState(() => _isEvaluating = true);
+
+    final result = await RegexTesterService.test(
       pattern: _patternController.text,
       input: _inputController.text,
       caseSensitive: _caseSensitive,
@@ -42,7 +52,14 @@ class _RegexTesterScreenState extends State<RegexTesterScreen> {
       dotAll: _dotAll,
       unicode: _unicode,
     );
-    setState(() => _result = result);
+
+    // Only apply if this is still the latest request.
+    if (id == _requestId && mounted) {
+      setState(() {
+        _result = result;
+        _isEvaluating = false;
+      });
+    }
   }
 
   void _applyCommonPattern(String pattern) {
@@ -172,6 +189,13 @@ class _RegexTesterScreenState extends State<RegexTesterScreen> {
           ),
           const SizedBox(height: 16),
 
+          // Loading indicator
+          if (_isEvaluating)
+            const Padding(
+              padding: EdgeInsets.only(bottom: 8),
+              child: LinearProgressIndicator(),
+            ),
+
           // Results summary
           if (result != null && result.error == null) ...[
             Card(
@@ -197,6 +221,14 @@ class _RegexTesterScreenState extends State<RegexTesterScreen> {
                         style: theme.textTheme.bodyMedium?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
+                      ),
+                    ],
+                    if (result.truncated) ...[
+                      const SizedBox(width: 16),
+                      Tooltip(
+                        message: 'Results capped at ${RegexTesterService.maxMatches} matches',
+                        child: Icon(Icons.warning_amber,
+                            color: Colors.orange, size: 20),
                       ),
                     ],
                   ],


### PR DESCRIPTION
## Problem

The RegexTesterService executed user-supplied regular expressions synchronously on the UI thread with no input size limits or timeout. A crafted pattern with catastrophic backtracking (e.g. (a+)+$ against 'aaaaaaaaaaaaaaa!') could freeze the app indefinitely (ReDoS).

## Solution

- Isolate execution with 3-second timeout
- Input limits: pattern 1 KB, test input 100 KB
- Match cap at 1000 to prevent memory exhaustion
- Async UI with progress indicator and stale-result cancellation
- Truncation warning indicator

Severity: High