### PR TITLE
fix: include symptom_tracker_entries in backup service

### DIFF
--- a/lib/core/services/data_backup_service.dart
+++ b/lib/core/services/data_backup_service.dart
@@ -77,6 +77,7 @@ class DataBackupService {
     'fasting_tracker_entries': 'Fasting Tracker',
     'daily_journal_entries': 'Daily Journal',
     'emergency_card_data': 'Emergency Card',
+    'symptom_tracker_entries': 'Symptom Tracker',
   };
 
   /// Reads a value from the appropriate storage backend.


### PR DESCRIPTION
symptom_tracker_entries was in SensitiveKeys (encrypted at rest) but missing from DataBackupService._storageKeys. Symptom data was silently excluded from exports and rejected on import. Data loss bug for users who backup/restore.